### PR TITLE
Allow any provider for SLF4J import.

### DIFF
--- a/bundletree/pom.xml
+++ b/bundletree/pom.xml
@@ -41,10 +41,7 @@
 				<extensions>true</extensions>
 				<configuration>
 					<instructions>
-						<Import-Package>
-							org.slf4j;provider=paxlogging,
-							*
-						</Import-Package>
+						<Import-Package>*</Import-Package>
 						<Export-Package>
 							org.mqnaas.bundletree,
 							org.mqnaas.bundletree.exceptions,

--- a/clientprovider/pom.xml
+++ b/clientprovider/pom.xml
@@ -44,10 +44,7 @@
 				<extensions>true</extensions>
 				<configuration>
 					<instructions>
-						<Import-Package>
-							org.slf4j;provider=paxlogging,
-							*
-						</Import-Package>
+						<Import-Package>*</Import-Package>
 						<Export-Package>
 							org.mqnaas.clientprovider.api.apiclient,
 							org.mqnaas.clientprovider.api.client

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -58,10 +58,7 @@
 				<configuration>
 					<instructions>
 						<Bundle-Activator>org.mqnaas.core.impl.Activator</Bundle-Activator>
-						<Import-Package>
-							org.slf4j;provider=paxlogging,
-							*
-						</Import-Package>
+						<Import-Package>*</Import-Package>
 						<Export-Package>
 							org.mqnaas.core.impl,
 							org.mqnaas.core.impl.notificationfilter

--- a/examples/junosRouter/pom.xml
+++ b/examples/junosRouter/pom.xml
@@ -40,10 +40,7 @@
 				<extensions>true</extensions>
 				<configuration>
 					<instructions>
-						<Import-Package>
-							org.slf4j;provider=paxlogging,
-							*
-						</Import-Package>
+						<Import-Package>*</Import-Package>
 						<Export-Package>
 							org.mqnaas.examples.junosrouter
 						</Export-Package>

--- a/examples/openerRouter/pom.xml
+++ b/examples/openerRouter/pom.xml
@@ -40,10 +40,7 @@
 				<extensions>true</extensions>
 				<configuration>
 					<instructions>
-						<Import-Package>
-							org.slf4j;provider=paxlogging,
-							*
-						</Import-Package>
+						<Import-Package>*</Import-Package>
 						<Export-Package>
 							org.mqnaas.examples.openerRouter
 						</Export-Package>

--- a/examples/testapp/pom.xml
+++ b/examples/testapp/pom.xml
@@ -45,10 +45,7 @@
 				<extensions>true</extensions>
 				<configuration>
 					<instructions>
-						<Import-Package>
-							org.slf4j;provider=paxlogging,
-							*
-						</Import-Package>
+						<Import-Package>*</Import-Package>
 						<Export-Package>
 							org.mqnaas.examples.testapp
 						</Export-Package>


### PR DESCRIPTION
It is not necessary to force Pax Logging as SL4J provider for our bundles. It will allow using them in any other OSGi system with any other Logging framework supporting SLF4J API. In Apache Karaf Pax Logging will be used as default option.
