### PR TITLE
Avoid bad initialization of application instances.

### DIFF
--- a/core/src/main/java/org/mqnaas/core/impl/ApplicationInstance.java
+++ b/core/src/main/java/org/mqnaas/core/impl/ApplicationInstance.java
@@ -46,7 +46,14 @@ public class ApplicationInstance extends AbstractInstance<IApplication> {
 	private ExecutionRelayingInvocationHandler							invocationHandler;
 
 	public ApplicationInstance(Class<? extends IApplication> clazz) {
+		this(clazz, null);
+
+	}
+
+	public ApplicationInstance(Class<? extends IApplication> clazz, IApplication instance) {
 		super(clazz);
+
+		this.instance = instance;
 
 		internalServices = ArrayListMultimap.create();
 
@@ -71,15 +78,8 @@ public class ApplicationInstance extends AbstractInstance<IApplication> {
 		proxy = (IApplication) Proxy.newProxyInstance(getInstance().getClass().getClassLoader(),
 				appClasses.toArray(new Class[appClasses.size()]), invocationHandler);
 
-	}
-
-	public ApplicationInstance(Class<? extends IApplication> clazz, IApplication instance) {
-		this(clazz);
-
-		this.instance = instance;
-
-		if (instance instanceof IExecutionService) {
-			executionService = (IExecutionService) instance;
+		if (getInstance() instanceof IExecutionService) {
+			executionService = (IExecutionService) getInstance();
 		}
 	}
 

--- a/core/src/main/java/org/mqnaas/core/impl/CapabilityInstance.java
+++ b/core/src/main/java/org/mqnaas/core/impl/CapabilityInstance.java
@@ -38,7 +38,7 @@ public class CapabilityInstance extends ApplicationInstance {
 	private IResource									resource;
 
 	public CapabilityInstance(Class<? extends ICapability> clazz) {
-		super(clazz);
+		this(clazz, null);
 	}
 
 	public CapabilityInstance(Class<? extends ICapability> clazz, ICapability instance) {

--- a/core/src/main/java/org/mqnaas/core/impl/Service.java
+++ b/core/src/main/java/org/mqnaas/core/impl/Service.java
@@ -41,6 +41,7 @@ public class Service implements IInternalService {
 
 		try {
 			result = metaData.getMethod().invoke(metaData.getApplication(), parameters);
+			// FIXME fail gracefully and/or notify errors
 		} catch (IllegalArgumentException e) {
 			e.printStackTrace();
 		} catch (IllegalAccessException e) {

--- a/core/src/test/java/org/mqnaas/core/impl/BindingManagementReactsToResourcesTest.java
+++ b/core/src/test/java/org/mqnaas/core/impl/BindingManagementReactsToResourcesTest.java
@@ -27,8 +27,8 @@ public class BindingManagementReactsToResourcesTest {
 	static ISampleMgmtCapability	sampleMgmtCapability;
 	static IExecutionService		executionService;
 
-	boolean							addExecuted		= false;
-	boolean							removeExecuted	= false;
+	volatile boolean				addExecuted		= false;
+	volatile boolean				removeExecuted	= false;
 
 	@BeforeClass
 	public static void init() throws Exception {


### PR DESCRIPTION
In `ApplicationInstance` and `CapabilityInstance` avoid bad instance initialization changing the constructors strategy. This solves some `NullPointerException`s.
