### PR TITLE
Support for adding custom JAX-RS providers.

### DIFF
--- a/clientprovider/src/main/java/org/mqnaas/client/cxf/CXFConfiguration.java
+++ b/clientprovider/src/main/java/org/mqnaas/client/cxf/CXFConfiguration.java
@@ -1,8 +1,16 @@
 package org.mqnaas.client.cxf;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class CXFConfiguration {
 
-	private boolean	useDummyClient;
+	private boolean			useDummyClient;
+	private List<Object>	providers;
+
+	public CXFConfiguration() {
+		providers = new ArrayList<Object>();
+	}
 
 	/**
 	 * Specifies whether a dummy client is desired or not. A dummy client is not a valid client and does not perform any other activity than logging.
@@ -20,6 +28,25 @@ public class CXFConfiguration {
 	 */
 	public void setUseDummyClient(boolean useDummyClient) {
 		this.useDummyClient = useDummyClient;
+	}
+
+	/**
+	 * Returns the list of customs JAX-RS providers of this configuration.
+	 * 
+	 * @return Collection of JAX-RS providers.
+	 */
+	public List<Object> getProviders() {
+		return providers;
+	}
+
+	/**
+	 * Set a list of JAX-RS provider to this CXFConfiguration. It would be used by the {@link InternalCXFClientProvider} as custom provider for
+	 * serializing/deserializing data.
+	 * 
+	 * @param providers
+	 */
+	public void setProviders(List<Object> providers) {
+		this.providers = providers;
 	}
 
 	/*

--- a/clientprovider/src/main/java/org/mqnaas/client/cxf/InternalCXFClientProvider.java
+++ b/clientprovider/src/main/java/org/mqnaas/client/cxf/InternalCXFClientProvider.java
@@ -56,7 +56,9 @@ public class InternalCXFClientProvider implements IInternalAPIProvider<CXFConfig
 		JAXRSClientFactoryBean bean = new JAXRSClientFactoryBean();
 		bean.setAddress(ep.getUri().toString());
 
-		// bean.setProvider(new CustomJSONProvider()); // TODO initialize the rest from the configuration
+		if (!configuration.getProviders().isEmpty())
+			bean.setProviders(configuration.getProviders());
+
 		bean.setResourceClass(apiClass);
 		bean.setClassLoader(classLoader);
 


### PR DESCRIPTION
CXFConfiguration receives a list of custom providers, used by the JAXRSClientFactoryBean as JAX-RS providers.

Since it receives a list of Objects, our implementation is forced to receive it as well.
