### PR TITLE
Test Helpers JAR

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -296,6 +296,7 @@
 		<module>bundletree/itests-testbundleA</module>
 		<module>bundletree/itests-testbundleB</module>
 		<module>clientprovider</module>
+		<module>test-helpers</module>
 	</modules>
 
 	<repositories>

--- a/test-helpers/pom.xml
+++ b/test-helpers/pom.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+	<parent>
+		<groupId>org.mqnaas</groupId>
+		<artifactId>mqnaas</artifactId>
+		<version>0.0.1-SNAPSHOT</version>
+	</parent>
+
+	<modelVersion>4.0.0</modelVersion>
+	<artifactId>test-helpers</artifactId>
+	<name>MQNaaS :: Test Helpers</name>
+	<description>MQNaaS Test Helpers</description>
+	<packaging>jar</packaging>
+
+	<dependencies>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+		</dependency>
+	</dependencies>
+
+</project>

--- a/test-helpers/src/main/java/org/mqnaas/test/helpers/ReflectionTestHelper.java
+++ b/test-helpers/src/main/java/org/mqnaas/test/helpers/ReflectionTestHelper.java
@@ -1,0 +1,50 @@
+package org.mqnaas.test.helpers;
+
+import java.lang.reflect.Field;
+
+/**
+ * Reflection Test Helpers
+ * 
+ * @author Julio Carlos Barrera
+ *
+ */
+public class ReflectionTestHelper {
+
+	/**
+	 * Injects a private {@link Field} fieldInstance (instance of F) into classInstance (instance of T). It uses fieldName to look for private field.
+	 * 
+	 * @param classInstance
+	 *            target instance
+	 * @param fieldInstance
+	 *            field instance to be injected
+	 * @param fieldName
+	 *            target field name
+	 * @throws SecurityException
+	 *             if this exception is thrown during the process
+	 * @throws IllegalArgumentException
+	 *             if fieldName could not be found in classInstance {@link Class} or if fieldInstance is not a compatible type to be injected
+	 * @throws IllegalAccessException
+	 *             if this exception is thrown during the process
+	 */
+	public static <T, F> void injectPrivateField(T classInstance, F fieldInstance, String fieldName) throws SecurityException,
+			IllegalArgumentException, IllegalAccessException {
+
+		@SuppressWarnings("unchecked")
+		Class<T> clazz = (Class<T>) classInstance.getClass();
+
+		Field field;
+		try {
+			field = clazz.getDeclaredField(fieldName);
+		} catch (NoSuchFieldException e) {
+			throw new IllegalArgumentException("Invalid fieldName received, a field with this name can not be found.", e);
+		}
+		if (!field.getType().isAssignableFrom(fieldInstance.getClass())) {
+			throw new IllegalArgumentException("Invalid fieldName received, fieldInstance can not assigned to field.");
+		}
+
+		field.setAccessible(true);
+		field.set(classInstance, fieldInstance);
+		field.setAccessible(false);
+	}
+
+}

--- a/test-helpers/src/test/java/org/mqnaas/test/helpers/ReflectionTestHelperTests.java
+++ b/test-helpers/src/test/java/org/mqnaas/test/helpers/ReflectionTestHelperTests.java
@@ -1,0 +1,50 @@
+package org.mqnaas.test.helpers;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Unit tests of {@link ReflectionTestHelper}
+ * 
+ * @author Julio Carlos Barrera
+ *
+ */
+public class ReflectionTestHelperTests {
+
+	private static final String	TEST_STRING	= "test_string";
+
+	@Test
+	public void testInjectPrivateField() throws SecurityException, IllegalArgumentException, IllegalAccessException {
+		TestClass testClass = new TestClass();
+		ReflectionTestHelper.injectPrivateField(testClass, TEST_STRING, "privateCharSequence");
+		Assert.assertEquals("Field must be injected.", TEST_STRING, testClass.getPrivateCharSequence());
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testBadTypeInjectPrivateField() throws SecurityException, IllegalArgumentException, IllegalAccessException {
+		TestClass testClass = new TestClass();
+		ReflectionTestHelper.injectPrivateField(testClass, new Object(), "privateCharSequence");
+
+		// with the parameterized approach this error could not be produced in runtime because it is produced at compile time.
+		//
+		// in this example it produces this compiler error:
+		// "The parameterized method <TestClass, String>injectPrivateField(TestClass, String, String) of type ReflectionTestHelper
+		// is not applicable for the arguments (TestClass, Object, String)"
+		//
+		// ReflectionTestHelper.<TestClass, String> injectPrivateField(testClass, new Object(), "privateCharSequence");
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testBadFieldNameInjectPrivateField() throws SecurityException, IllegalArgumentException, IllegalAccessException {
+		TestClass testClass = new TestClass();
+		ReflectionTestHelper.injectPrivateField(testClass, TEST_STRING, "BAD_FIELD_NAME");
+	}
+
+	@Test
+	public void testParameterizedInjectPrivateField() throws SecurityException, IllegalArgumentException, IllegalAccessException {
+		TestClass testClass = new TestClass();
+		ReflectionTestHelper.<TestClass, String> injectPrivateField(testClass, TEST_STRING, "privateCharSequence");
+		Assert.assertEquals("Field must be injected.", TEST_STRING, testClass.getPrivateCharSequence());
+	}
+
+}

--- a/test-helpers/src/test/java/org/mqnaas/test/helpers/TestClass.java
+++ b/test-helpers/src/test/java/org/mqnaas/test/helpers/TestClass.java
@@ -1,0 +1,17 @@
+package org.mqnaas.test.helpers;
+
+/**
+ * Class for testing purposes
+ * 
+ * @author Julio Carlos Barrera
+ *
+ */
+public class TestClass {
+
+	private CharSequence	privateCharSequence;
+
+	public CharSequence getPrivateCharSequence() {
+		return privateCharSequence;
+	}
+
+}


### PR DESCRIPTION
Create JAR project with test helpers to be used in any unit test of other modules.

Now only contains `ReflectionTestHelper` class with one static method to inject values into private fields.
