### PR TITLE
Add needed OSGi exports.

### DIFF
--- a/clientprovider/pom.xml
+++ b/clientprovider/pom.xml
@@ -60,7 +60,9 @@
 				<configuration>
 					<instructions>
 						<Import-Package>*</Import-Package>
-						<Export-Package></Export-Package>
+						<Export-Package>
+							org.mqnaas.client.cxf
+						</Export-Package>
 					</instructions>
 				</configuration>
 			</plugin>


### PR DESCRIPTION
It is necessary to export CXF client package in order to be used in other bundles.
