### PR TITLE
Fix/specify karaf version in itests

### DIFF
--- a/bundletree/itests/src/test/java/org/mqnaas/bundletree/test/BundleGuardTest.java
+++ b/bundletree/itests/src/test/java/org/mqnaas/bundletree/test/BundleGuardTest.java
@@ -37,6 +37,8 @@ public class BundleGuardTest {
 
 	@Configuration
 	public Option[] config() {
+		// FIXME Read mqnass features version from maven.
+		// now mqnaas features version in this file must be changed manually in each release!
 		return new Option[] {
 				// distribution to test: Karaf 3.0.1
 				KarafDistributionOption.karafDistributionConfiguration()

--- a/bundletree/itests/src/test/java/org/mqnaas/bundletree/utils/test/BundleUtilsTest.java
+++ b/bundletree/itests/src/test/java/org/mqnaas/bundletree/utils/test/BundleUtilsTest.java
@@ -36,6 +36,8 @@ public class BundleUtilsTest {
 
 	@Configuration
 	public Option[] config() {
+		// FIXME Read mqnass features version from maven. Same applies for bundletree-itests-testbundleX version
+		// now mqnaas features version in this file must be changed manually in each release!
 		return new Option[] {
 				// distribution to test: Karaf 3.0.1
 				KarafDistributionOption.karafDistributionConfiguration()


### PR DESCRIPTION
Use karaf version 3.0.1 in itests.

Must tell maven to install same karaf version the application is targeting (3.0.1)
When not specified, maven was installing LATEST version, which is not desired.

Using currently LATEST (4.0.0.M1) causes errors and results in test not passing.
