### PR TITLE
Use javax.ws.rs-api in core.api as in rest bundle.

### DIFF
--- a/core.api/pom.xml
+++ b/core.api/pom.xml
@@ -14,10 +14,6 @@
 	<description>MQNaaS Core API</description>
 	<packaging>bundle</packaging>
 
-	<properties>
-		<jsr311-api-version>1.1.1</jsr311-api-version>
-	</properties>
-
 	<dependencies>
 		<dependency>
 			<groupId>com.google.guava</groupId>
@@ -29,8 +25,7 @@
 		</dependency>
 		<dependency>
 			<groupId>javax.ws.rs</groupId>
-			<artifactId>jsr311-api</artifactId>
-			<version>${jsr311-api-version}</version>
+			<artifactId>javax.ws.rs-api</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.cxf</groupId>

--- a/src/main/resources/features.xml
+++ b/src/main/resources/features.xml
@@ -47,7 +47,8 @@
 		<!-- bundle dependencies -->
 		<bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.asm/${asm-version}</bundle>
 		<bundle dependency="true">mvn:org.apache.commons/commons-lang3/${commons-lang3}</bundle>
-		<bundle dependency="true">mvn:javax.ws.rs/javax.ws.rs-api/2.0</bundle>
+		<bundle dependency="true">mvn:javax.ws.rs/javax.ws.rs-api/${javax.ws.rs-api-version}</bundle>
+		
 		<!-- TODO Uncommenting this dependency leads to a runtime dependency problem -->
 		<!-- bundle dependency="true">mvn:org.slf4j/slf4j-api/${slf4j-version}</bundle-->
 		


### PR DESCRIPTION
Core.APi was using different library for javax.ws.rs classes in runtime and compilation. This pull request fix a problem on feature startup.
