### PR TITLE
API publishes capability proxies.

### DIFF
--- a/api.rest/src/main/java/org/mqnaas/api/APIConnector.java
+++ b/api.rest/src/main/java/org/mqnaas/api/APIConnector.java
@@ -155,7 +155,7 @@ public class APIConnector implements IAPIConnector {
 			String uri = getPathForApplication(capabilityNode, capabClass, new StringBuffer()).toString();
 			log.debug("Publishing API for interface {} of capability {} with path {}", capabClass.getName(), capabilityNode.getContent()
 					.getInstance(), uri);
-			restApiProvider.publish((ICapability) capabilityNode.getContent().getInstance(), capabClass, uri);
+			restApiProvider.publish((ICapability) capabilityNode.getContent().getProxy(), capabClass, uri);
 		}
 	}
 

--- a/core/src/main/java/org/mqnaas/core/impl/ApplicationInstance.java
+++ b/core/src/main/java/org/mqnaas/core/impl/ApplicationInstance.java
@@ -244,7 +244,7 @@ public class ApplicationInstance {
 		instance = null;
 	}
 
-	IApplication getProxy() {
+	public IApplication getProxy() {
 		return proxyHolder.getProxy();
 	}
 


### PR DESCRIPTION
This way, every call to the API is executed as a Service in the execution Service (by using the proxy).
This is the way they are meant to be executed.

This way, observations are appropiatedly triggered, resulting in platform desired behaviour.
