### PR TITLE
Revert "SliceAdministration implements isSupporting."

### DIFF
--- a/core/src/main/java/org/mqnaas/core/impl/slicing/SliceAdministration.java
+++ b/core/src/main/java/org/mqnaas/core/impl/slicing/SliceAdministration.java
@@ -43,10 +43,6 @@ public class SliceAdministration implements ISliceAdministration {
 	public SliceAdministration() {
 	}
 
-	public static boolean isSupporting(IResource resource) {
-		return (resource instanceof Slice);
-	}
-
 	@Override
 	public void activate() {
 		units = new CopyOnWriteArrayList<Unit>();


### PR DESCRIPTION
Reverts dana-i2cat/mqnaas#107

Is it correct to bind SliceAdministration to a Slice???
Who is responsible of creating a Slice, then???
Some discussion is required.
