### PR TITLE
Fix/slice bug

### DIFF
--- a/core/src/main/java/org/mqnaas/core/impl/slicing/SliceAdministration.java
+++ b/core/src/main/java/org/mqnaas/core/impl/slicing/SliceAdministration.java
@@ -552,7 +552,7 @@ public class SliceAdministration implements ISliceAdministration {
 
 		@Override
 		public boolean execute(Object dataOfOtherSlice, int[] coords) {
-			if (get(currentData, coords)) {
+			if (get(dataOfOtherSlice, coords)) {
 
 				// Start the fill along all axis from that point
 				int n = coords.length;


### PR DESCRIPTION
The compactize operation works with a copy of the slice information, so the clearOperation does not remove its information.
