### PR TITLE
Modify network creation to add slice to its IRootResouceProvider. Do not call reservation capability.

### DIFF
--- a/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/Network.java
+++ b/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/Network.java
@@ -31,7 +31,7 @@ public class Network {
 	}
 
 	public List<IRootResource> getResources() {
-		return getCapability(IRootResourceProvider.class).getRootResources();
+		return getRootResourceProvider().getRootResources();
 	}
 
 	public <C extends ICapability> C getCapability(Class<C> capabilityClass) {
@@ -73,11 +73,16 @@ public class Network {
 		return getCapability(IRootResourceAdministration.class);
 	}
 
-	private IRootResourceProvider getRootResourceProvider() {
+	public IRootResourceProvider getRootResourceProvider() {
 		return getCapability(IRootResourceProvider.class);
 	}
 
 	public List<IRootResource> getRootResources(Type type, String model, String version) throws ResourceNotFoundException {
 		return getRootResourceProvider().getRootResources(type, model, version);
+	}
+
+	public void setRootResources(List<IRootResource> virtualNetworkResources) {
+		getRootResourceProvider().setRootResources(virtualNetworkResources);
+
 	}
 }


### PR DESCRIPTION
- Wrapper for the network resource (virtualNetwork)
- Do not call reservation capability: Nitos IRequestBasedNetworkManagement capability will reserve its devices, and the other resources will be "reserved" by creating a slice. We assume the reservation will be immediately done. (This wil change after the demo)

Commented code contains first version of the request for the nitos IRequestBasedNetworkManagement creation. Stil to be improved.
