### PR TITLE
Test/network management

### DIFF
--- a/core/src/main/java/org/mqnaas/core/impl/slicing/AbstractCXFSlicingCapability.java
+++ b/core/src/main/java/org/mqnaas/core/impl/slicing/AbstractCXFSlicingCapability.java
@@ -34,7 +34,7 @@ public abstract class AbstractCXFSlicingCapability implements ISlicingCapability
 
 	protected Map<IRootResource, Server>	proxiesEndpoints;
 
-	Collection<IResource>					virtualResources;
+	protected Collection<IResource>			virtualResources;
 
 	@Override
 	public void activate() {

--- a/core/src/main/java/org/mqnaas/core/impl/slicing/SliceProvider.java
+++ b/core/src/main/java/org/mqnaas/core/impl/slicing/SliceProvider.java
@@ -29,7 +29,9 @@ public class SliceProvider implements ISliceProvider {
 	}
 
 	public static boolean isSupporting(IRootResource resource) {
-		return resource.getDescriptor().getSpecification().getType() == Type.TSON;
+		Type resourceType = resource.getDescriptor().getSpecification().getType();
+
+		return resourceType.equals(Type.TSON) || resourceType.equals(Type.OF_SWITCH);
 	}
 
 	public static boolean isSupporting(IResource resource) {
@@ -43,7 +45,7 @@ public class SliceProvider implements ISliceProvider {
 
 				Type type = (Type) m.invoke(resource);
 
-				isSupporting = type.equals(Type.TSON);
+				isSupporting = type.equals(Type.TSON) || type.equals(type.OF_SWITCH);
 			} catch (Exception e) {
 				e.printStackTrace();
 			}

--- a/extensions/network/itests/pom.xml
+++ b/extensions/network/itests/pom.xml
@@ -28,7 +28,7 @@
 		<dependency>
 			<groupId>org.mqnaas.extensions</groupId>
 			<artifactId>network.impl</artifactId>
-		</dependency>				
+		</dependency>
 		<!-- Tests libraries-->
 		<dependency>
 			<groupId>junit</groupId>
@@ -62,8 +62,11 @@
 			<artifactId>apache-karaf</artifactId>
 			<type>tar.gz</type>
 			<scope>test</scope>
-		</dependency> 
-
-
+		</dependency> 			
+		<dependency>
+			<groupId>com.github.tomakehurst</groupId>
+			<artifactId>wiremock</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/extensions/network/itests/src/test/java/org/mqnaas/extensions/network/itests/NetworkManagementTest.java
+++ b/extensions/network/itests/src/test/java/org/mqnaas/extensions/network/itests/NetworkManagementTest.java
@@ -1,16 +1,27 @@
 package org.mqnaas.extensions.network.itests;
 
+import java.io.BufferedReader;
 import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 
 import javax.inject.Inject;
+import javax.ws.rs.core.MediaType;
 
+import net.i2cat.dana.nitos.client.model.LeaseResourcesResponse;
+import net.i2cat.dana.nitos.client.model.Resource;
+import net.i2cat.dana.nitos.client.model.ResourceResponse;
+
+import org.eclipse.jetty.http.HttpStatus;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mqnaas.core.api.Endpoint;
@@ -49,6 +60,9 @@ import org.ops4j.pax.exam.spi.reactors.PerClass;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+
 /**
  * 
  * @author Adrián Roselló Rey (i2CAT)
@@ -58,12 +72,17 @@ import org.slf4j.LoggerFactory;
 @ExamReactorStrategy(PerClass.class)
 public class NetworkManagementTest {
 
-	private static final Logger	log	= LoggerFactory.getLogger(NetworkManagementTest.class);
+	private static final Logger	log				= LoggerFactory.getLogger(NetworkManagementTest.class);
 
 	private Network				networkResource;
 	private NetworkSubResource	tsonResource;
+	private Network				nitosResource;
+
 	private NetworkSubResource	ofSwitchResource1;
 	private NetworkSubResource	ofSwitchResource2;
+
+	@Rule
+	public WireMockRule			wireMockRule	= new WireMockRule(8080);
 
 	@Inject
 	IServiceProvider			serviceProvider;
@@ -101,6 +120,8 @@ public class NetworkManagementTest {
 				// add tson features
 				KarafDistributionOption.features(CoreOptions.maven().groupId("net.i2cat.dana.tson").artifactId("tson").classifier("features")
 						.type("xml").version("0.0.1-SNAPSHOT"), "tson"),
+				KarafDistributionOption.features(CoreOptions.maven().groupId("org.mqnaas").artifactId("mqnaas").classifier("features")
+						.type("xml").version("0.0.1-SNAPSHOT"), "mqnaas-wiremock"),
 		// debug option
 		// KarafDistributionOption.debugConfiguration()
 		};
@@ -120,13 +141,16 @@ public class NetworkManagementTest {
 	 * @throws URISyntaxException
 	 * @throws CapabilityNotFoundException
 	 * @throws ResourceNotFoundException
+	 * @throws IOException
 	 */
 	@Before
 	public void prepareTest() throws InstantiationException, IllegalAccessException, URISyntaxException, CapabilityNotFoundException,
-			ResourceNotFoundException {
+			ResourceNotFoundException, IOException {
+
+		mockServer();
 
 		Endpoint tsonEndpoint = new Endpoint(new URI("http://www.myfaketson.com/tson"));
-		Endpoint nitosendpoint = new Endpoint(new URI("http://www.myfakenitos.com/nitos"));
+		Endpoint nitosendpoint = new Endpoint(new URI("http://localhost:8080"));
 
 		// 1. create resources
 
@@ -137,6 +161,11 @@ public class NetworkManagementTest {
 		// // 1.b create physical tson (in physical network)
 		IRootResource tson = networkResource.createResource(new Specification(Type.TSON), Arrays.asList(tsonEndpoint));
 		tsonResource = new NetworkSubResource(tson, serviceProvider);
+
+		// // 1.c create nitos network
+		IRootResource nitos = networkResource.createResource(new Specification(Type.NETWORK, "nitos"), Arrays.asList(nitosendpoint));
+		nitosResource = new Network(nitos, serviceProvider);
+
 		// 2. create resources ports
 		// // 2.1. create tson ports
 		tsonResource.createPort();
@@ -294,5 +323,54 @@ public class NetworkManagementTest {
 
 		Slice tsonSlice = new Slice(tsonResource.getSlice(), serviceProvider);
 		Assert.assertEquals("Physical TSON should contain original slice information again.", "XX", tsonSlice.toMatrix());
+	}
+
+	private LeaseResourcesResponse generateLeaseResourcesResponse() {
+
+		LeaseResourcesResponse response = new LeaseResourcesResponse();
+		ResourceResponse resourceResponse = new ResourceResponse();
+
+		List<Resource> resources = new ArrayList<Resource>();
+
+		Resource resource = new Resource();
+
+		resource.setName("ofswitch");
+		resource.setType(net.i2cat.dana.nitos.client.model.Type.OF_SWITCH);
+		resource.setHref("http://www.myfakenitos.com/ofswitch");
+
+		resource.setUuid(Type.OF_SWITCH + "-1");
+
+		resources.add(resource);
+
+		resourceResponse.setResources(resources);
+		response.setResourceResponse(resourceResponse);
+
+		return response;
+	}
+
+	private void mockServer() throws IOException {
+		String getResourcesresponse = textFileToString("/mock/getResourcesNitosResponse.json");
+
+		WireMock.stubFor(
+				WireMock.get(
+						WireMock.urlEqualTo("/resources/nodes"))
+						.withHeader("Content-Type", WireMock.equalTo(MediaType.APPLICATION_JSON))
+						.willReturn(WireMock.aResponse()
+								.withStatus(HttpStatus.OK_200)
+								.withHeader("Content-Type", MediaType.APPLICATION_JSON)
+								.withBody(getResourcesresponse)
+						));
+	}
+
+	private String textFileToString(String fileLocation) throws IOException {
+		String fileString = "";
+		BufferedReader br = new BufferedReader(
+				new InputStreamReader(getClass().getResourceAsStream(fileLocation)));
+		String line;
+		while ((line = br.readLine()) != null) {
+			fileString += line += "\n";
+		}
+		br.close();
+		return fileString;
 	}
 }

--- a/extensions/network/itests/src/test/java/org/mqnaas/extensions/network/itests/NetworkManagementTest.java
+++ b/extensions/network/itests/src/test/java/org/mqnaas/extensions/network/itests/NetworkManagementTest.java
@@ -122,8 +122,8 @@ public class NetworkManagementTest {
 						.type("xml").version("0.0.1-SNAPSHOT"), "tson"),
 				KarafDistributionOption.features(CoreOptions.maven().groupId("org.mqnaas").artifactId("mqnaas").classifier("features")
 						.type("xml").version("0.0.1-SNAPSHOT"), "mqnaas-wiremock"),
-				// debug option
-				KarafDistributionOption.debugConfiguration(),
+		// debug option
+		// KarafDistributionOption.debugConfiguration(),
 		};
 
 	}

--- a/extensions/network/itests/src/test/java/org/mqnaas/extensions/network/itests/NetworkManagementTest.java
+++ b/extensions/network/itests/src/test/java/org/mqnaas/extensions/network/itests/NetworkManagementTest.java
@@ -122,8 +122,8 @@ public class NetworkManagementTest {
 						.type("xml").version("0.0.1-SNAPSHOT"), "tson"),
 				KarafDistributionOption.features(CoreOptions.maven().groupId("org.mqnaas").artifactId("mqnaas").classifier("features")
 						.type("xml").version("0.0.1-SNAPSHOT"), "mqnaas-wiremock"),
-		// debug option
-		// KarafDistributionOption.debugConfiguration()
+				// debug option
+				KarafDistributionOption.debugConfiguration()
 		};
 
 	}
@@ -199,9 +199,20 @@ public class NetworkManagementTest {
 
 		// // 2.1 add request resources and mapping
 
+		// // // 2.1.1 tson
 		IResource reqTsonResource = request.createResource(Type.TSON);
 		NetworkSubResource reqTson = new NetworkSubResource(reqTsonResource, serviceProvider);
 		request.defineMapping(reqTsonResource, tsonResource.getResource());
+
+		// // // 2.2.2 nitos
+		IResource reqNitosResource = request.createResource(Type.NETWORK);
+		Network reqNitos = new Network(reqNitosResource, serviceProvider);
+		request.defineMapping(reqNitosResource, nitosResource.getNetworkResource());
+
+		// // // 2.2.3 ofswitch in nitos
+		IRootResource phyOfSwitch = nitosResource.getRootResources().get(0);
+		IResource ofswitch = reqNitos.createRequestResource(Type.OF_SWITCH);
+		request.defineMapping(ofswitch, phyOfSwitch);
 
 		// // 2.2 specify internal ports
 

--- a/extensions/network/itests/src/test/resources/mock/getResourcesNitosResponse.json
+++ b/extensions/network/itests/src/test/resources/mock/getResourcesNitosResponse.json
@@ -3,7 +3,7 @@
       "resources":[
          {
             "uuid":"f8020202-7c11-459c-89ee-4997bf9ad7e9",
-            "href":"/resources/152187ce-23d6-4a7e-8863-3f6375ab0d37",
+            "href":"/resources/f8020202-7c11-459c-89ee-4997bf9ad7e9",
             "name":"ofswitch",
             "account":{
                "uuid":"962f4b0e-115f-4ad8-ae34-be5d8111d487",

--- a/extensions/network/itests/src/test/resources/mock/getResourcesNitosResponse.json
+++ b/extensions/network/itests/src/test/resources/mock/getResourcesNitosResponse.json
@@ -1,0 +1,40 @@
+{
+   "resource_response":{
+      "resources":[
+         {
+            "uuid":"f8020202-7c11-459c-89ee-4997bf9ad7e9",
+            "href":"/resources/152187ce-23d6-4a7e-8863-3f6375ab0d37",
+            "name":"ofswitch",
+            "account":{
+               "uuid":"962f4b0e-115f-4ad8-ae34-be5d8111d487",
+               "href":"/resources/498c0b9c-df70-489f-913a-c5a35f9de06d",
+               "type":"account"
+            },
+            "type":"openflow",
+            "interfaces":[
+               {
+                  "uuid":"a562dcfd-e092-48c1-badb-8d2361b03abd",
+                  "href":"/resources/a562dcfd-e092-48c1-badb-8d2361b03abd",
+                  "name":"node016:if0",
+                  "type":"interface",
+                  "role":"control",
+                  "mac":"00:03:1D:07:98:18",
+                  "ip":{
+                     "uuid":"417e0468-fb05-44a2-8d90-f99eed5c2b32",
+                     "href":"/resources/417e0468-fb05-44a2-8d90-f99eed5c2b32",
+                     "name":"r70083534334220",
+                     "type":"ip",
+                     "address":"10.0.1.16",
+                     "netmask":"255.255.255.0",
+                     "ip_type":"ipv4"
+                  },
+                  "description":"1 Gbpsethernet",
+                  "domain":"omf:testserver",
+                  "available":true,
+                  "status":"unknown"
+               }
+            ]
+         }
+      ]
+   }
+}

--- a/extensions/network/itests/src/test/resources/mock/leaseResourceNitosResponse.json
+++ b/extensions/network/itests/src/test/resources/mock/leaseResourceNitosResponse.json
@@ -1,0 +1,30 @@
+{
+   "resource_response":{
+      "resource":{
+         "uuid":"fg6523ft-cv4v-12ds-89eq-1990ghdcv7u0",
+         "href":"/resources/leases//fg6523ft-cv4v-12ds-89eq-1990ghdcv7u0",
+         "name":"testlease",
+         "account":{
+            "uuid":"962f4b0e-115f-4ad8-ae34-be5d8111d487",
+            "href":"/resources/leases//962f4b0e-115f-4ad8-ae34-be5d8111d487",
+            "name":"i2cat",
+            "type":"account"
+         },
+         "type":"Lease",
+         "components":[
+            {
+               "component":{
+                  "uuid":"f8020202-7c11-459c-89ee-4997bf9ad7e9",
+                  "href":"/resources/leases//f8020202-7c11-459c-89ee-4997bf9ad7e9",
+                  "name":"ofswitch",
+                  "type":"openflow"
+               }
+            }
+         ],
+         "valid_from":"2014-05-26 17:00:00 +0200",
+         "valid_until":"2014-05-26 19:00:00 +0200",
+         "status":"accepted"
+      },
+      "about":"/resources/leases/ "
+   }
+}	

--- a/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/Network.java
+++ b/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/Network.java
@@ -72,6 +72,10 @@ public class Network implements IRootResourceProvider {
 
 	}
 
+	public IResource createRequestResource(Type type) {
+		return getCapability(IRequestResourceManagement.class).createResource(type);
+	}
+
 	private IRootResourceAdministration getRootResourceAdministration() {
 		return getCapability(IRootResourceAdministration.class);
 	}

--- a/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/NetworkManagement.java
+++ b/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/NetworkManagement.java
@@ -104,11 +104,11 @@ public class NetworkManagement implements IRequestBasedNetworkManagement {
 				}
 
 				// If the resource is a subnetwork, create request and delegate to it
-				IRequestBasedNetworkManagement subnetManagementCapability = virtualResource.getRequestBasedNetworkManagementCapability();
+				IRequestBasedNetworkManagement subnetManagementCapability = phyResource.getRequestBasedNetworkManagementCapability();
 				if (subnetManagementCapability != null) {
 					Network subNetwork = new Network(virtualResource.getResource(), serviceProvider);
 					Network virtualSubNetwork = delegateToSubnetwork(request, subNetwork);
-					virtualNetworkResources.addAll(virtualSubNetwork.getRootResources());
+					virtualNetworkResources.add((IRootResource) virtualSubNetwork.getNetworkResource());
 					virtualSubnetworks.add(virtualNetwork.getNetworkResource());
 
 					resourceMapping.put(virtualSubNetwork.getNetworkResource(), virtualResource.getResource());
@@ -145,37 +145,37 @@ public class NetworkManagement implements IRequestBasedNetworkManagement {
 			NetworkCreationException {
 
 		// generate request
-		IResource subNetRequestresource = subnetwork.createRequest();
+		IResource phynetworkResource = request.getMappedDevice(subnetwork.getNetworkResource());
+		Network phyNetwork = new Network(phynetworkResource, serviceProvider);
+
+		IResource subNetRequestresource = phyNetwork.createRequest();
 		Request subnetRequest = new Request(subNetRequestresource, serviceProvider);
 
 		// get subnetwork resources and fill the request with the resources
 		for (IResource subnetResource : subnetwork.getNetworkSubResources()) {
 			IResource virtResource = request.createResource(((RequestRootResource) subnetResource).getType());
-			request.defineMapping(virtResource, subnetResource);
+			IResource phySubResource = request.getMappedDevice(subnetResource);
+			request.defineMapping(virtResource, phySubResource);
 		}
 
-		// get links and fill the request with the links
-		for (IResource linkResource : subnetwork.getLinks()) {
-
-			Link phyLink = new Link(linkResource, serviceProvider);
-			Link virtLink = new Link(request.createLink(), serviceProvider);
-
-			IResource srcPort = request.getMappedDevice(phyLink.getSrcPort());
-			IResource dstPort = request.getMappedDevice(phyLink.getDstPort());
-
-			virtLink.setSrcPort(srcPort);
-			virtLink.setDstPort(dstPort);
-		}
+		// // get links and fill the request with the links
+		// for (IResource linkResource : subnetwork.getLinks()) {
+		//
+		// Link phyLink = new Link(linkResource, serviceProvider);
+		// Link virtLink = new Link(request.createLink(), serviceProvider);
+		//
+		// IResource srcPort = request.getMappedDevice(phyLink.getSrcPort());
+		// IResource dstPort = request.getMappedDevice(phyLink.getDstPort());
+		//
+		// virtLink.setSrcPort(srcPort);
+		// virtLink.setDstPort(dstPort);
+		// }
 
 		// set period
 		subnetRequest.setPeriod(request.getPeriod());
 
-		IRootResource virtualNetResource = subnetwork.createVirtualNetwork(subnetRequest.getRequestResource());
+		IRootResource virtualNetResource = phyNetwork.createVirtualNetwork(subnetRequest.getRequestResource());
 
-		Network virtualNetwork = new Network(virtualNetResource, serviceProvider);
-		List<IRootResource> subnetResources = virtualNetwork.getRootResources();
-
-		// TODO what to do with the network?!?!
 		return new Network(virtualNetResource, serviceProvider);
 	}
 

--- a/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/NetworkManagement.java
+++ b/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/NetworkManagement.java
@@ -153,9 +153,9 @@ public class NetworkManagement implements IRequestBasedNetworkManagement {
 
 		// get subnetwork resources and fill the request with the resources
 		for (IResource subnetResource : subnetwork.getNetworkSubResources()) {
-			IResource virtResource = request.createResource(((RequestRootResource) subnetResource).getType());
+			IResource virtResource = subnetRequest.createResource(((RequestRootResource) subnetResource).getType());
 			IResource phySubResource = request.getMappedDevice(subnetResource);
-			request.defineMapping(virtResource, phySubResource);
+			subnetRequest.defineMapping(virtResource, phySubResource);
 		}
 
 		// // get links and fill the request with the links

--- a/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/NetworkRootResourceProvider.java
+++ b/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/NetworkRootResourceProvider.java
@@ -56,9 +56,9 @@ public class NetworkRootResourceProvider implements IRootResourceProvider {
 			Specification specification = resource.getDescriptor().getSpecification();
 
 			boolean matches = true;
-			matches &= type != null ? specification.getType().equals(type) : true;
-			matches &= model != null ? specification.getModel().equals(model) : true;
-			matches &= version != null ? specification.getVersion().equals(version) : true;
+			matches &= (type != null && specification.getType() != null) ? specification.getType().equals(type) : true;
+			matches &= (model != null && specification.getModel() != null) ? specification.getModel().equals(model) : true;
+			matches &= (version != null && specification.getVersion() != null) ? specification.getVersion().equals(version) : true;
 
 			if (matches)
 				filteredResources.add(resource);

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -43,7 +43,9 @@
 		<!-- Apache Commons IO version -->
 		<commons-io.version>2.4</commons-io.version>
 		
-
+		<!-- Wiremock version -->
+		<wiremock.version>1.51</wiremock.version>
+		
 		<!-- Javax Inject version -->
 		<javax.inject.version>1_2</javax.inject.version>
 		
@@ -118,6 +120,12 @@
 				<groupId>xmlunit</groupId>
 				<artifactId>xmlunit</artifactId>
 				<version>${xmlunit.version}</version>
+				<scope>test</scope>
+			</dependency>
+			<dependency>
+				<groupId>com.github.tomakehurst</groupId>
+				<artifactId>wiremock</artifactId>
+				<version>${wiremock.version}</version>
 				<scope>test</scope>
 			</dependency>
 			<!-- IO Utils -->


### PR DESCRIPTION
This code finish the implementation of the networkManagement test.

The physical network consists of:

- tson resource
- nitos resource with openflow resource.

The test was adapted to include the subnetwork (nitos with  openflow) in the request. The pull request fix several bugs found during test execution

