### PR TITLE
NetworkManagement is aware of ports translations. 

### DIFF
--- a/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/PortResourceWrapper.java
+++ b/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/PortResourceWrapper.java
@@ -40,6 +40,10 @@ public class PortResourceWrapper {
 		}
 	}
 
+	public IResource getPortResource() {
+		return port;
+	}
+
 	private IAttributeStore getAttributeStore() throws CapabilityNotFoundException {
 		return serviceProvider.getCapability(port, IAttributeStore.class);
 	}


### PR DESCRIPTION
NetworkManagement stores the physical port id in the AttributeStore capability of the virtual ports.

Test was adapted to update to new feature, as well as fix some conceptual error. (There were three ports but the original slice contained only 2...)