### PR TITLE
Modify equals to fix unit resource lookup.

### DIFF
--- a/core/src/main/java/org/mqnaas/core/impl/slicing/Unit.java
+++ b/core/src/main/java/org/mqnaas/core/impl/slicing/Unit.java
@@ -42,7 +42,7 @@ public class Unit {
 
 		Unit other = (Unit) o;
 
-		return unit.equals(other.unit);
+		return unit.matches(other.unit);
 	}
 
 	public void setRange(Range range) {

--- a/core/src/main/java/org/mqnaas/core/impl/slicing/UnitResource.java
+++ b/core/src/main/java/org/mqnaas/core/impl/slicing/UnitResource.java
@@ -61,11 +61,25 @@ public class UnitResource implements IResource, Serializable {
 	public String getId() {
 		return id;
 	}
+	
+	public boolean matches(UnitResource other) {
+		if (other == null)
+			return false;
+		if (name == null) {
+			if (other.name != null)
+				return false;
+		} else if (!name.equals(other.name))
+			return false;
+		if (type != other.type)
+			return false;
+		return true;
+	}
 
 	@Override
 	public int hashCode() {
 		final int prime = 31;
 		int result = 1;
+		result = prime * result + ((id == null) ? 0 : id.hashCode());
 		result = prime * result + ((name == null) ? 0 : name.hashCode());
 		result = prime * result + ((type == null) ? 0 : type.hashCode());
 		return result;
@@ -80,6 +94,11 @@ public class UnitResource implements IResource, Serializable {
 		if (getClass() != obj.getClass())
 			return false;
 		UnitResource other = (UnitResource) obj;
+		if (id == null) {
+			if (other.id != null)
+				return false;
+		} else if (!id.equals(other.id))
+			return false;
 		if (name == null) {
 			if (other.name != null)
 				return false;
@@ -92,7 +111,8 @@ public class UnitResource implements IResource, Serializable {
 
 	@Override
 	public String toString() {
-		return "SliceUnit [name=" + name + ", type=" + type + "]";
+		return "UnitResource [id=" + id + ", name=" + name + ", type=" + type
+				+ "]";
 	}
 
 }


### PR DESCRIPTION
Resources are meant to be equals only when they represent the same resource.
Thus, the UnitResource id must be included in the equals

Units represent the same concept when they have same name and same type.
Thus Units are equal when they contain UnitResources with same name and type (but ignoring their resource id.)