### PR TITLE
Fix/virtual network api

### DIFF
--- a/api.rest/src/main/java/org/mqnaas/api/writers/CapabilityMetaDataContainer.java
+++ b/api.rest/src/main/java/org/mqnaas/api/writers/CapabilityMetaDataContainer.java
@@ -45,8 +45,8 @@ class CapabilityMetaDataContainer {
 	 */
 	public CapabilityMetaDataContainer(Class<? extends ICapability> capabilityClass) throws InvalidCapabilityDefinionException {
 
-		// All methods defined in the capability are services
-		services = new ArrayList<Method>(Arrays.asList(capabilityClass.getDeclaredMethods()));
+		// All methods defined in the capability interface are services (inherited ones, too)
+		services = new ArrayList<Method>(Arrays.asList(capabilityClass.getMethods()));
 
 		// All resource entities used in the services are collected to be able to check them
 		Set<Class<?>> entityClasses = new HashSet<Class<?>>();

--- a/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/NetworkManagement.java
+++ b/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/NetworkManagement.java
@@ -335,7 +335,7 @@ public class NetworkManagement implements IRequestBasedNetworkManagement {
 
 	@Override
 	public Collection<IRootResource> getNetworks() {
-		return networks.keySet();
+		return new ArrayList<IRootResource>(networks.keySet());
 	}
 
 	@Override


### PR DESCRIPTION
This patch allows the retrieval of virtual network resources through the calls:

GET http://localhost:9000/mqnaas/IRootResourceAdministration/PHYSICAL_NETWORK_ID
/IRequestBasedNetworkManagement/

GET http://localhost:9000/mqnaas/IRootResourceAdministration/PHYSICAL_NETWORK_ID
/IRequestBasedNetworkManagement/VIRTUAL_NETWORK_ID
