### PR TITLE
Virtual resources created by SlicingCapability bound to virtual network

### DIFF
--- a/core.api/src/main/java/org/mqnaas/core/api/IServiceProvider.java
+++ b/core.api/src/main/java/org/mqnaas/core/api/IServiceProvider.java
@@ -72,4 +72,6 @@ public interface IServiceProvider extends ICapability {
 	 * FIXME This is a service to play with during development and will not be part of the final API
 	 */
 	void printAvailableServices();
+
+	<C extends ICapability> C getCapabilityInstance(IResource resource, Class<C> capabilityClass) throws CapabilityNotFoundException;
 }

--- a/core.api/src/main/java/org/mqnaas/core/api/slicing/ISlicingCapability.java
+++ b/core.api/src/main/java/org/mqnaas/core/api/slicing/ISlicingCapability.java
@@ -19,10 +19,10 @@ import org.mqnaas.core.api.annotations.RemovesResource;
  */
 public interface ISlicingCapability extends ICapability {
 
-	@AddsResource
+	// @AddsResource
 	IResource createSlice(IResource slice) throws SlicingException;
 
-	@RemovesResource
+	// @RemovesResource
 	void removeSlice(IResource rootResource) throws SlicingException;
 
 	@ListsResources

--- a/core/src/main/java/org/mqnaas/core/impl/BindingManagement.java
+++ b/core/src/main/java/org/mqnaas/core/impl/BindingManagement.java
@@ -907,11 +907,22 @@ public class BindingManagement implements IServiceProvider, IResourceManagementL
 	// safe-casting of classes, checked previously
 	@SuppressWarnings("unchecked")
 	public <C extends ICapability> C getCapability(IResource resource, Class<C> capabilityClass) throws CapabilityNotFoundException {
+		return (C) getCapabilityInternalInstance(resource, capabilityClass).getProxy();
+	}
+	
+	@Override
+	// safe-casting of classes, checked previously
+	@SuppressWarnings("unchecked")
+	public <C extends ICapability> C getCapabilityInstance(IResource resource, Class<C> capabilityClass) throws CapabilityNotFoundException {
+		return (C) getCapabilityInternalInstance(resource, capabilityClass).getInstance();
+	}
+	
+	private CapabilityInstance getCapabilityInternalInstance(IResource resource, Class<? extends ICapability> capabilityClass) throws CapabilityNotFoundException {
 
 		Iterable<CapabilityInstance> resourceCapabilities = filterResolved(getCapabilityInstancesBoundToResource(resource));
 		for (CapabilityInstance capabilityInstance : resourceCapabilities)
 			if (capabilityInstance.getCapabilities().contains(capabilityClass))
-				return (C) capabilityInstance.getProxy();
+				return capabilityInstance;
 
 		throw new CapabilityNotFoundException(
 				"Resource " + resource.getId() + " does not contain any resolved capability of type " + capabilityClass.getName());

--- a/core/src/test/java/org/mqnaas/core/impl/slicing/SliceAdministrationTest.java
+++ b/core/src/test/java/org/mqnaas/core/impl/slicing/SliceAdministrationTest.java
@@ -170,6 +170,12 @@ public class SliceAdministrationTest {
 			throw new RuntimeException("Not implemented.");
 		}
 
+		@Override
+		public <C extends ICapability> C getCapabilityInstance(IResource resource, Class<C> capabilityClass)
+				throws CapabilityNotFoundException {
+			throw new RuntimeException("Not implemented.");
+		}
+
 	}
 
 	@Test

--- a/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/NetworkManagement.java
+++ b/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/NetworkManagement.java
@@ -257,7 +257,7 @@ public class NetworkManagement implements IRequestBasedNetworkManagement {
 
 		// manual bind of the created slice to virtualnetwork
 		resourceManagementListener.resourceAdded(newResource,
-				serviceProvider.getCapability(virtualNetwork.getNetworkResource(), IRootResourceProvider.class), IRootResourceProvider.class);
+				serviceProvider.getCapabilityInstance(virtualNetwork.getNetworkResource(), IRootResourceProvider.class), IRootResourceProvider.class);
 
 		// remove slice information from physical
 		phySlice.cut(virtSlice);


### PR DESCRIPTION
Virtual resources created by SlicingCapability are bound to virtual network IRootResourceProvider.

When processing a VIR, the NetworkManagement manually binds sliced resources to the newly created virtual network.
In order to achieve that, createSlice must not bind the newly created slice to itseld (thus, @Adds Resource annotation is not desired.), otherwise
the manually bind attempt will silently fail.

In order for the manual bind to succeed, addsResource() should be called with
the capability instance instead of the proxy.
This is achieved by using getCapabilityInstance service from serviceProvider.