### PR TITLE
karaf 3.0.2 compatible

### DIFF
--- a/clientprovider/src/main/java/org/mqnaas/client/cxf/InternalCXFClientProvider.java
+++ b/clientprovider/src/main/java/org/mqnaas/client/cxf/InternalCXFClientProvider.java
@@ -73,8 +73,7 @@ public class InternalCXFClientProvider<CC extends CXFConfiguration> implements I
 		// TODO use switch id to instantiate the client
 
 		// create CXF client
-		ProxyClassLoader classLoader = new ProxyClassLoader();
-		classLoader.addLoader(apiClass.getClassLoader());
+		ProxyClassLoader classLoader = new ProxyClassLoader(apiClass.getClassLoader());
 		classLoader.addLoader(JAXRSClientFactoryBean.class.getClassLoader());
 
 		JAXRSClientFactoryBean bean = new JAXRSClientFactoryBean();
@@ -162,8 +161,7 @@ public class InternalCXFClientProvider<CC extends CXFConfiguration> implements I
 
 	private <API> API createDummyClient(Class<API> apiClass) {
 
-		ProxyClassLoader classLoader = new ProxyClassLoader();
-		classLoader.addLoader(apiClass.getClassLoader());
+		ProxyClassLoader classLoader = new ProxyClassLoader(apiClass.getClassLoader());
 
 		// It is safe to cast returned proxy to one of the interfaces given to newProxyInstance method, according to its contract:
 		// Proxy.newProxyInstance javadoc:

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
 		<javax.ws.rs-api-version>2.0-m10</javax.ws.rs-api-version>
 
 		<!-- Apache CXF bundle version -->
-		<cxf-version>2.7.10</cxf-version>
+		<cxf-version>2.7.14</cxf-version>
 
 		<!-- SLF4J version -->
 		<slf4j-version>1.7.7</slf4j-version>


### PR DESCRIPTION
This patch causes mqnaas to be correctly deployed in karaf 3.0.2.
Current compatibility with karaf 3.0.1 is maintained.

In order to achieve it's goal, this patch upgrades cxf version from 2.7.10 to 2.7.14

There was an "Unresolved constraint" error when deploying cxf 2.7.10 feature in karaf 3.0.2.
However there are no errors with cxf 2.7.14 feature in karaf 3.0.2.

This patch solves issue http://jira.i2cat.net/browse/OPENNAAS-1504



