### PR TITLE
Add exception to be thrown when an application can not initialize its internal model

### DIFF
--- a/core.api/src/main/java/org/mqnaas/core/api/exceptions/InternalModelInitializationException.java
+++ b/core.api/src/main/java/org/mqnaas/core/api/exceptions/InternalModelInitializationException.java
@@ -1,0 +1,33 @@
+package org.mqnaas.core.api.exceptions;
+
+import org.mqnaas.core.api.IApplication;
+
+/**
+ * <p>
+ * Exception to be thrown by services initializing the internal model of a {@link IApplication}.
+ * </p>
+ * 
+ * @author Adrián Roselló Rey (i2CAT)
+ *
+ */
+public class InternalModelInitializationException extends Exception {
+
+	private static final long	serialVersionUID	= 1902148520708811010L;
+
+	public InternalModelInitializationException() {
+		super();
+	}
+
+	public InternalModelInitializationException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public InternalModelInitializationException(String message) {
+		super(message);
+	}
+
+	public InternalModelInitializationException(Throwable cause) {
+		super(cause);
+	}
+
+}


### PR DESCRIPTION
This pull request propose a new exception to be used by capabilities and also for the rest of applications. 

In enet-38xx and olt resources, the PortManagement capability initialize its model on activation. Exceptions were  only logged, but not handled. So, I suggest to use this exception in similar cases.