### PR TITLE
Refactor/reservation capab

### DIFF
--- a/extensions/network/network.api/pom.xml
+++ b/extensions/network/network.api/pom.xml
@@ -54,6 +54,7 @@
 							org.mqnaas.network.api.exceptions,
 							org.mqnaas.network.api.infrastructure,
 							org.mqnaas.network.api.request,
+							org.mqnaas.network.api.reservation,							
 							org.mqnaas.network.api.topology,
 							org.mqnaas.network.api.topology.port,
 							org.mqnaas.network.api.topology.link,

--- a/extensions/network/network.api/src/main/java/org/mqnaas/network/api/reservation/IReservationAdministration.java
+++ b/extensions/network/network.api/src/main/java/org/mqnaas/network/api/reservation/IReservationAdministration.java
@@ -19,7 +19,9 @@ public interface IReservationAdministration extends ICapability {
 	public enum ReservationState {
 		CREATED,
 		PLANNED,
-		RESERVED
+		RESERVED,
+		CANCELLED,
+		FINISHED
 	}
 
 	void setResources(Set<IRootResource> resources);

--- a/extensions/network/network.api/src/main/java/org/mqnaas/network/api/reservation/IReservationAdministration.java
+++ b/extensions/network/network.api/src/main/java/org/mqnaas/network/api/reservation/IReservationAdministration.java
@@ -1,0 +1,37 @@
+package org.mqnaas.network.api.reservation;
+
+import java.util.Set;
+
+import org.mqnaas.core.api.ICapability;
+import org.mqnaas.core.api.IRootResource;
+import org.mqnaas.network.api.request.Period;
+
+/**
+ * <p>
+ * Capability managing the {@link IRootResource}s, {@link Period} and state of a {@link ReservationResource}
+ * </p>
+ * 
+ * @author Adrián Roselló Rey (i2CAT)
+ *
+ */
+public interface IReservationAdministration extends ICapability {
+
+	public enum ReservationState {
+		CREATED,
+		PLANNED,
+		RESERVED
+	}
+
+	void setResources(Set<IRootResource> resources);
+
+	void setPeriod(Period period);
+
+	void setState(ReservationState state);
+
+	Set<IRootResource> getResources();
+
+	Period getPeriod();
+
+	ReservationState getState();
+
+}

--- a/extensions/network/network.api/src/main/java/org/mqnaas/network/api/reservation/IReservationManagement.java
+++ b/extensions/network/network.api/src/main/java/org/mqnaas/network/api/reservation/IReservationManagement.java
@@ -1,0 +1,30 @@
+package org.mqnaas.network.api.reservation;
+
+import java.util.List;
+
+import org.mqnaas.core.api.ICapability;
+import org.mqnaas.core.api.IResource;
+import org.mqnaas.core.api.annotations.AddsResource;
+import org.mqnaas.core.api.annotations.ListsResources;
+import org.mqnaas.core.api.annotations.RemovesResource;
+
+/**
+ * <p>
+ * Management capability for {@link ReservationResource} resources.
+ * </p>
+ * 
+ * @author Adrián Roselló Rey (i2CAT)
+ *
+ */
+public interface IReservationManagement extends ICapability {
+
+	@AddsResource
+	IResource createReservation();
+
+	@RemovesResource
+	void removeReservation(IResource reservation);
+
+	@ListsResources
+	List<IResource> getReservations();
+
+}

--- a/extensions/network/network.api/src/main/java/org/mqnaas/network/api/reservation/IReservationManagement.java
+++ b/extensions/network/network.api/src/main/java/org/mqnaas/network/api/reservation/IReservationManagement.java
@@ -7,6 +7,7 @@ import org.mqnaas.core.api.IResource;
 import org.mqnaas.core.api.annotations.AddsResource;
 import org.mqnaas.core.api.annotations.ListsResources;
 import org.mqnaas.core.api.annotations.RemovesResource;
+import org.mqnaas.network.api.reservation.IReservationAdministration.ReservationState;
 
 /**
  * <p>
@@ -26,5 +27,7 @@ public interface IReservationManagement extends ICapability {
 
 	@ListsResources
 	List<IResource> getReservations();
+
+	List<IResource> getReservations(ReservationState state);
 
 }

--- a/extensions/network/network.api/src/main/java/org/mqnaas/network/api/reservation/IReservationPerformer.java
+++ b/extensions/network/network.api/src/main/java/org/mqnaas/network/api/reservation/IReservationPerformer.java
@@ -1,0 +1,18 @@
+package org.mqnaas.network.api.reservation;
+
+/**
+ * 
+ * <p>
+ * Capability performing resources reservations.
+ * </p>
+ * 
+ * @author Adrián Roselló Rey (i2CAT)
+ *
+ */
+public interface IReservationPerformer {
+
+	void performReservation(ReservationResource reservation);
+
+	void cancelReservation(ReservationResource reservation);
+
+}

--- a/extensions/network/network.api/src/main/java/org/mqnaas/network/api/reservation/IReservationPerformer.java
+++ b/extensions/network/network.api/src/main/java/org/mqnaas/network/api/reservation/IReservationPerformer.java
@@ -1,5 +1,7 @@
 package org.mqnaas.network.api.reservation;
 
+import org.mqnaas.core.api.ICapability;
+
 /**
  * 
  * <p>
@@ -9,7 +11,7 @@ package org.mqnaas.network.api.reservation;
  * @author Adrián Roselló Rey (i2CAT)
  *
  */
-public interface IReservationPerformer {
+public interface IReservationPerformer extends ICapability {
 
 	void performReservation(ReservationResource reservation);
 

--- a/extensions/network/network.api/src/main/java/org/mqnaas/network/api/reservation/IReservationPlanner.java
+++ b/extensions/network/network.api/src/main/java/org/mqnaas/network/api/reservation/IReservationPlanner.java
@@ -1,0 +1,28 @@
+package org.mqnaas.network.api.reservation;
+
+import java.util.Set;
+
+import org.mqnaas.core.api.ICapability;
+import org.mqnaas.core.api.IRootResource;
+import org.mqnaas.network.api.request.Period;
+
+/**
+ * <p>
+ * Capability managing resources reservation planning.
+ * </p>
+ * <p>
+ * This capability allows to reserve OpenNaaS {@link IRootResource}s for a specific {@link Period} of time. Reservations for a specific resource are
+ * only allowed if the resource is available in this period of time, i.e. it does not exist any other reservation containing this resource during the
+ * same time.
+ * </p>
+ * 
+ * @author Adrián Roselló Rey (i2CAT)
+ *
+ */
+public interface IReservationPlanner extends ICapability {
+
+	void planReservation(ReservationResource reservation, Set<IRootResource> resources, Period period);
+
+	void cancelPlannedReservation(ReservationResource reservation);
+
+}

--- a/extensions/network/network.api/src/main/java/org/mqnaas/network/api/reservation/IReservationPlanner.java
+++ b/extensions/network/network.api/src/main/java/org/mqnaas/network/api/reservation/IReservationPlanner.java
@@ -21,8 +21,8 @@ import org.mqnaas.network.api.request.Period;
  */
 public interface IReservationPlanner extends ICapability {
 
-	void planReservation(ReservationResource reservation, Set<IRootResource> resources, Period period);
+	void planReservation(ReservationResource reservation, Set<IRootResource> resources, Period period) throws ResourceReservationException;
 
-	void cancelPlannedReservation(ReservationResource reservation);
+	void cancelPlannedReservation(ReservationResource reservation) throws ResourceReservationException;
 
 }

--- a/extensions/network/network.api/src/main/java/org/mqnaas/network/api/reservation/ReservationResource.java
+++ b/extensions/network/network.api/src/main/java/org/mqnaas/network/api/reservation/ReservationResource.java
@@ -1,0 +1,37 @@
+package org.mqnaas.network.api.reservation;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlTransient;
+
+import org.mqnaas.core.api.IResource;
+
+/**
+ * Basic reservation resource implementation providing a simple unique id.
+ * 
+ * 
+ * @author Adrián Roselló Rey (i2CAT)
+ *
+ */
+@XmlRootElement(namespace = "org.mqnaas")
+@XmlAccessorType(XmlAccessType.FIELD)
+public class ReservationResource implements IResource {
+
+	@XmlTransient
+	private static AtomicInteger	ID_COUNTER	= new AtomicInteger();
+
+	private String					id;
+
+	public ReservationResource() {
+		id = "reservation-" + ID_COUNTER.incrementAndGet();
+	}
+
+	@Override
+	public String getId() {
+		return id;
+	}
+
+}

--- a/extensions/network/network.api/src/main/java/org/mqnaas/network/api/reservation/ReservationResource.java
+++ b/extensions/network/network.api/src/main/java/org/mqnaas/network/api/reservation/ReservationResource.java
@@ -34,4 +34,34 @@ public class ReservationResource implements IResource {
 		return id;
 	}
 
+	@Override
+	public String toString() {
+		return "ReservationResource [id=" + id + "]";
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((id == null) ? 0 : id.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		ReservationResource other = (ReservationResource) obj;
+		if (id == null) {
+			if (other.id != null)
+				return false;
+		} else if (!id.equals(other.id))
+			return false;
+		return true;
+	}
+
 }

--- a/extensions/network/network.api/src/main/java/org/mqnaas/network/api/reservation/ResourceReservationException.java
+++ b/extensions/network/network.api/src/main/java/org/mqnaas/network/api/reservation/ResourceReservationException.java
@@ -1,0 +1,31 @@
+package org.mqnaas.network.api.reservation;
+
+/**
+ * 
+ * @author Adrián Roselló Rey (i2CAT)
+ *
+ */
+public class ResourceReservationException extends Exception {
+
+	/**
+	 * 
+	 */
+	private static final long	serialVersionUID	= -8077229848023802861L;
+
+	public ResourceReservationException() {
+		super();
+	}
+
+	public ResourceReservationException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public ResourceReservationException(String message) {
+		super(message);
+	}
+
+	public ResourceReservationException(Throwable cause) {
+		super(cause);
+	}
+
+}

--- a/extensions/network/network.impl/pom.xml
+++ b/extensions/network/network.impl/pom.xml
@@ -42,7 +42,19 @@
 			<artifactId>junit</artifactId>
 			<scope>test</scope>
 		</dependency>
-		
+		<dependency>
+			<groupId>org.mqnaas</groupId>
+			<artifactId>test-helpers</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.powermock</groupId>
+			<artifactId>powermock-api-mockito</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.powermock</groupId>
+			<artifactId>powermock-module-junit4</artifactId>
+		</dependency>
 
 	</dependencies>
 

--- a/extensions/network/network.impl/pom.xml
+++ b/extensions/network/network.impl/pom.xml
@@ -50,10 +50,12 @@
 		<dependency>
 			<groupId>org.powermock</groupId>
 			<artifactId>powermock-api-mockito</artifactId>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.powermock</groupId>
 			<artifactId>powermock-module-junit4</artifactId>
+			<scope>test</scope>
 		</dependency>
 
 	</dependencies>

--- a/extensions/network/network.impl/pom.xml
+++ b/extensions/network/network.impl/pom.xml
@@ -36,6 +36,14 @@
 			<artifactId>reservation-capability</artifactId>
 		</dependency>
 
+		<!-- Testing -->
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<scope>test</scope>
+		</dependency>
+		
+
 	</dependencies>
 
 	<build>

--- a/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/reservation/ReservationAdministration.java
+++ b/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/reservation/ReservationAdministration.java
@@ -1,0 +1,77 @@
+package org.mqnaas.network.impl.reservation;
+
+import java.util.Set;
+
+import org.mqnaas.core.api.IResource;
+import org.mqnaas.core.api.IRootResource;
+import org.mqnaas.core.api.annotations.Resource;
+import org.mqnaas.core.api.exceptions.ApplicationActivationException;
+import org.mqnaas.network.api.request.Period;
+import org.mqnaas.network.api.reservation.IReservationAdministration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * 
+ * @author Adrián Roselló Rey (i2CAT)
+ *
+ */
+public class ReservationAdministration implements IReservationAdministration {
+
+	private static final Logger	log	= LoggerFactory.getLogger(ReservationAdministration.class);
+
+	private Period				period;
+	private Set<IRootResource>	resources;
+	private ReservationState	state;
+
+	@Resource
+	IResource					resource;
+
+	@Override
+	public void activate() throws ApplicationActivationException {
+		log.info("Initializing ReservationAdministration capability for resource " + resource.getId());
+
+		state = ReservationState.CREATED;
+
+		log.info("Initialized ReservationAdministration capability for resource " + resource.getId());
+	}
+
+	@Override
+	public void deactivate() {
+		log.info("Removing ReservationAdministration capability of resource " + resource.getId());
+
+		log.info("Removing ReservationAdministration capability of resource " + resource.getId());
+
+	}
+
+	@Override
+	public Period getPeriod() {
+		return period;
+	}
+
+	@Override
+	public void setPeriod(Period period) {
+		this.period = period;
+	}
+
+	@Override
+	public Set<IRootResource> getResources() {
+		return resources;
+	}
+
+	@Override
+	public void setResources(Set<IRootResource> resources) {
+		this.resources = resources;
+	}
+
+	@Override
+	public ReservationState getState() {
+		return state;
+	}
+
+	@Override
+	public void setState(ReservationState state) {
+		this.state = state;
+	}
+
+}

--- a/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/reservation/ReservationManagement.java
+++ b/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/reservation/ReservationManagement.java
@@ -1,0 +1,115 @@
+package org.mqnaas.network.impl.reservation;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import org.mqnaas.core.api.IResource;
+import org.mqnaas.core.api.IRootResource;
+import org.mqnaas.core.api.IServiceProvider;
+import org.mqnaas.core.api.annotations.DependingOn;
+import org.mqnaas.core.api.annotations.Resource;
+import org.mqnaas.core.api.exceptions.ApplicationActivationException;
+import org.mqnaas.core.api.exceptions.CapabilityNotFoundException;
+import org.mqnaas.network.api.request.Period;
+import org.mqnaas.network.api.reservation.IReservationAdministration;
+import org.mqnaas.network.api.reservation.IReservationAdministration.ReservationState;
+import org.mqnaas.network.api.reservation.IReservationManagement;
+import org.mqnaas.network.api.reservation.IReservationPerformer;
+import org.mqnaas.network.api.reservation.IReservationPlanner;
+import org.mqnaas.network.api.reservation.ReservationResource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * 
+ * @author Adrián Roselló Rey (i2CAT)
+ *
+ */
+public class ReservationManagement implements IReservationManagement, IReservationPlanner {
+
+	private static final Logger			log	= LoggerFactory.getLogger(ReservationManagement.class);
+
+	private List<ReservationResource>	reservations;
+
+	@Resource
+	IResource							resource;
+
+	@DependingOn
+	IReservationPerformer				reservationPerformer;
+
+	@DependingOn
+	IServiceProvider					serviceProvider;
+
+	@Override
+	public void activate() throws ApplicationActivationException {
+		log.info("Initializing ReservationManagement for resource " + resource.getId());
+
+		reservations = new CopyOnWriteArrayList<ReservationResource>();
+
+		log.info("Initialized ReservationManagement for resource " + resource.getId());
+
+	}
+
+	@Override
+	public void deactivate() {
+		log.info("Removing ReservationManagement from resource " + resource.getId());
+
+		// TODO cancel all reservations
+
+		log.info("Removed ReservationManagement from resource " + resource.getId());
+
+	}
+
+	@Override
+	public void planReservation(ReservationResource reservation, Set<IRootResource> resources, Period period) {
+		// TODO Auto-generated method stub
+
+	}
+
+	@Override
+	public void cancelPlannedReservation(ReservationResource reservation) {
+		// TODO Auto-generated method stub
+
+	}
+
+	@Override
+	public IResource createReservation() {
+
+		ReservationResource reservationResource = new ReservationResource();
+		reservations.add(reservationResource);
+		return reservationResource;
+	}
+
+	@Override
+	public void removeReservation(IResource reservation) {
+
+		if (reservation == null || !(reservation instanceof ReservationResource))
+			throw new IllegalArgumentException("Can only remove reservations resources.");
+
+		if (!reservations.contains(reservation))
+			throw new IllegalStateException("Didn't find reservation [id=" + reservation.getId() + "]. Can only remove existing reservations.");
+
+		IReservationAdministration reservationAdmin;
+		try {
+			reservationAdmin = serviceProvider.getCapability(reservation, IReservationAdministration.class);
+		} catch (CapabilityNotFoundException e) {
+			throw new IllegalStateException(
+					"Could not remove reservation[ " + reservation.getId() + "]. Could not get its IReservationAdministration capability.", e);
+		}
+
+		if (reservationAdmin.getState() != ReservationState.CREATED)
+			throw new IllegalStateException(
+					"Can only remove not planned nor performed reservations. Please release the reservation first. [ " + reservation
+							.getId() + ",state=" + reservationAdmin.getState() + "]");
+
+		reservations.remove(reservation);
+	}
+
+	@Override
+	public List<IResource> getReservations() {
+		return new ArrayList<IResource>(reservations);
+	}
+
+}

--- a/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/reservation/ReservationManagement.java
+++ b/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/reservation/ReservationManagement.java
@@ -1,17 +1,26 @@
 package org.mqnaas.network.impl.reservation;
 
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.mqnaas.core.api.IResource;
 import org.mqnaas.core.api.IRootResource;
+import org.mqnaas.core.api.IService;
 import org.mqnaas.core.api.IServiceProvider;
 import org.mqnaas.core.api.annotations.DependingOn;
 import org.mqnaas.core.api.annotations.Resource;
 import org.mqnaas.core.api.exceptions.ApplicationActivationException;
 import org.mqnaas.core.api.exceptions.CapabilityNotFoundException;
+import org.mqnaas.core.api.exceptions.ServiceExecutionSchedulerException;
+import org.mqnaas.core.api.exceptions.ServiceNotFoundException;
+import org.mqnaas.core.api.scheduling.IServiceExecutionScheduler;
+import org.mqnaas.core.api.scheduling.ServiceExecution;
+import org.mqnaas.core.api.scheduling.Trigger;
+import org.mqnaas.core.impl.scheduling.TriggerFactory;
 import org.mqnaas.network.api.request.Period;
 import org.mqnaas.network.api.reservation.IReservationAdministration;
 import org.mqnaas.network.api.reservation.IReservationAdministration.ReservationState;
@@ -19,6 +28,7 @@ import org.mqnaas.network.api.reservation.IReservationManagement;
 import org.mqnaas.network.api.reservation.IReservationPerformer;
 import org.mqnaas.network.api.reservation.IReservationPlanner;
 import org.mqnaas.network.api.reservation.ReservationResource;
+import org.mqnaas.network.api.reservation.ResourceReservationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -29,24 +39,27 @@ import org.slf4j.LoggerFactory;
  */
 public class ReservationManagement implements IReservationManagement, IReservationPlanner {
 
-	private static final Logger			log	= LoggerFactory.getLogger(ReservationManagement.class);
+	private static final Logger							log	= LoggerFactory.getLogger(ReservationManagement.class);
 
-	private List<ReservationResource>	reservations;
+	private Map<ReservationResource, ServiceExecution>	reservations;
 
 	@Resource
-	IResource							resource;
+	IResource											resource;
 
 	@DependingOn
-	IReservationPerformer				reservationPerformer;
+	IReservationPerformer								reservationPerformer;
 
 	@DependingOn
-	IServiceProvider					serviceProvider;
+	IServiceProvider									serviceProvider;
+
+	@DependingOn
+	IServiceExecutionScheduler							serviceExecutionScheduler;
 
 	@Override
 	public void activate() throws ApplicationActivationException {
 		log.info("Initializing ReservationManagement for resource " + resource.getId());
 
-		reservations = new CopyOnWriteArrayList<ReservationResource>();
+		reservations = new ConcurrentHashMap<ReservationResource, ServiceExecution>();
 
 		log.info("Initialized ReservationManagement for resource " + resource.getId());
 
@@ -63,14 +76,109 @@ public class ReservationManagement implements IReservationManagement, IReservati
 	}
 
 	@Override
-	public void planReservation(ReservationResource reservation, Set<IRootResource> resources, Period period) {
-		// TODO Auto-generated method stub
+	public void planReservation(ReservationResource reservation, Set<IRootResource> resources, Period period) throws ResourceReservationException {
+
+		if (reservation == null || period == null || resources == null)
+			throw new NullPointerException("Reservation, resources and period are required to plan a reservation.");
+
+		if (resources.isEmpty())
+			throw new IllegalArgumentException("You need at least one resource in order to plan a reservation");
+
+		log.info("Planning reservation [ " + reservation.getId() + "]");
+
+		ServiceExecution serviceExecution = null;
+		Date currentDate = getCurrentDate();
+
+		if (period.getStartdate().before(currentDate))
+			throw new IllegalArgumentException("The reservation period should be a future period.");
+
+		checkResourcesAreAvailable(reservation);
+
+		try {
+			IReservationAdministration reservationAdmin = serviceProvider.getCapability(reservation, IReservationAdministration.class);
+			reservationAdmin.setState(ReservationState.PLANNED);
+
+			if (reservationAdmin.getPeriod().getStartdate().after(new Date(System.currentTimeMillis()))) {
+				IService service = serviceProvider.getService(resource, "performReservation", ReservationResource.class);
+
+				Trigger trigger = TriggerFactory.create(reservationAdmin.getPeriod().getStartdate());
+				serviceExecution = new ServiceExecution(service, trigger);
+
+				reservations.put(reservation, serviceExecution);
+
+				serviceExecutionScheduler.schedule(serviceExecution);
+
+			}
+			else {
+				reservations.put(reservation, serviceExecution);
+				reservationPerformer.performReservation(reservation);
+			}
+		} catch (CapabilityNotFoundException c) {
+			throw new ResourceReservationException(c);
+		} catch (ServiceNotFoundException e) {
+			log.error("Could not obtain performReservation service.", e);
+			throw new ResourceReservationException(e);
+		} catch (ServiceExecutionSchedulerException e) {
+			throw new ResourceReservationException(e);
+		}
+
+	}
+
+	private void checkResourcesAreAvailable(ReservationResource reservation) throws ResourceReservationException {
+		try {
+			IReservationAdministration reservationAdmin = serviceProvider.getCapability(reservation, IReservationAdministration.class);
+
+			for (ReservationResource existingReservation : reservations.keySet()) {
+
+				// do not compare with current reservation, since it's stored in the map as well.
+				if (existingReservation.equals(reservation))
+					continue;
+
+				IReservationAdministration existingReservationAdmin = serviceProvider.getCapability(existingReservation,
+						IReservationAdministration.class);
+
+				if (!ReservationUtils.areResourcesAvailable(existingReservationAdmin, reservationAdmin))
+					throw new ResourceReservationException("Resource are not available during the requested period.");
+
+			}
+		} catch (CapabilityNotFoundException c) {
+			throw new ResourceReservationException("Could not plan reservation [" + reservation.getId() + "]", c);
+
+		}
 
 	}
 
 	@Override
-	public void cancelPlannedReservation(ReservationResource reservation) {
-		// TODO Auto-generated method stub
+	public void cancelPlannedReservation(ReservationResource reservation) throws ResourceReservationException {
+		if (reservation == null)
+			throw new NullPointerException("Reservation is required to cancel a reservation.");
+
+		if (!reservations.containsKey(reservation))
+			throw new ResourceReservationException("Could not cancel reservation: Reservation does not exists.");
+
+		log.info("Cancelling Reservation [" + reservation.getId() + "]");
+
+		try {
+			IReservationAdministration reservationAdmin = serviceProvider.getCapability(reservation, IReservationAdministration.class);
+
+			if (reservationAdmin.getState().equals(ReservationState.PLANNED))
+
+				try {
+					serviceExecutionScheduler.cancel(reservations.get(reservation));
+
+					reservations.remove(reservation);
+
+				} catch (ServiceExecutionSchedulerException e) {
+					throw new ResourceReservationException(e);
+				}
+			else
+				reservationPerformer.cancelReservation(reservation);
+
+		} catch (CapabilityNotFoundException c) {
+			throw new ResourceReservationException("Could not cancel reservation [" + reservation.getId() + "]", c);
+
+		}
+		log.info("Devices reservation cancelled.");
 
 	}
 
@@ -78,7 +186,7 @@ public class ReservationManagement implements IReservationManagement, IReservati
 	public IResource createReservation() {
 
 		ReservationResource reservationResource = new ReservationResource();
-		reservations.add(reservationResource);
+		reservations.put(reservationResource, null);
 		return reservationResource;
 	}
 
@@ -88,7 +196,7 @@ public class ReservationManagement implements IReservationManagement, IReservati
 		if (reservation == null || !(reservation instanceof ReservationResource))
 			throw new IllegalArgumentException("Can only remove reservations resources.");
 
-		if (!reservations.contains(reservation))
+		if (!reservations.containsKey(reservation))
 			throw new IllegalStateException("Didn't find reservation [id=" + reservation.getId() + "]. Can only remove existing reservations.");
 
 		IReservationAdministration reservationAdmin;
@@ -109,7 +217,20 @@ public class ReservationManagement implements IReservationManagement, IReservati
 
 	@Override
 	public List<IResource> getReservations() {
-		return new ArrayList<IResource>(reservations);
+		return new ArrayList<IResource>(reservations.keySet());
+	}
+
+	/**
+	 * Returns current date, decrementing 1 hour.
+	 * 
+	 * @return {@link Date} specifying 1 hour before the current date.
+	 */
+	private Date getCurrentDate() {
+
+		long currentTime = System.currentTimeMillis();
+
+		return new Date(currentTime - (1000 * 60 * 60));
+
 	}
 
 }

--- a/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/reservation/ReservationUtils.java
+++ b/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/reservation/ReservationUtils.java
@@ -1,0 +1,66 @@
+package org.mqnaas.network.impl.reservation;
+
+import org.mqnaas.core.api.IRootResource;
+import org.mqnaas.network.api.request.Period;
+import org.mqnaas.network.api.reservation.IReservationAdministration;
+import org.mqnaas.network.api.reservation.IReservationAdministration.ReservationState;
+import org.mqnaas.network.api.reservation.ReservationResource;
+
+/**
+ * Utilities for the reservation capability.
+ * 
+ * @author Adrián Roselló Rey (i2CAT)
+ *
+ */
+public class ReservationUtils {
+
+	/**
+	 * Checks if both periods overlap or not.
+	 * 
+	 * @param period1
+	 *            First period to be checked.
+	 * @param period2
+	 *            Second period to be checked.
+	 * @return <code>true</code> if both periods overlap. <code>false</code> otherwise.
+	 */
+	public static boolean periodsOverlap(Period period1, Period period2) {
+		if (period1.getEndDate().after(period2.getStartdate()) && period1.getEndDate().before(period2.getEndDate()))
+			return true;
+		if (period1.getStartdate().after(period2.getStartdate()) && period1.getStartdate().before(period2.getEndDate()))
+			return true;
+
+		if (period1.getStartdate().before(period2.getStartdate()) && period1.getEndDate().after(period2.getEndDate()))
+			return true;
+
+		return (period1.getStartdate().equals(period2.getStartdate()) || period1.getEndDate().equals(period2.getEndDate()) || period1.getStartdate()
+				.equals(period2.getEndDate()) || period1.getEndDate().equals(period2.getStartdate()));
+
+	}
+
+	/**
+	 * Checks if any {@link IRootResource} stored in the {@link IReservationAdministration} of a new {@link ReservationResource} are contained in the
+	 * <code>existingReservationAdmin</code> for the same {@link Period}.
+	 * 
+	 * @param existingReservation
+	 *            <code>IReservationAdministration</code> capability of an existing {@link ReservationResource}, containing its resources and period.
+	 * @param reservation
+	 *            <code>IReservationAdministration</code> capability of the new reservation to be checked.
+	 * @return <code>true</code> If the resources of the <code>reservationToCompareAdmin</code> object are not reserved during the
+	 *         <code>reservationToCompareAdmin</code> period. <code>false</code>, otherwise.
+	 */
+	public static boolean areResourcesAvailable(IReservationAdministration existingReservationAdmin,
+			IReservationAdministration reservationToCompareAdmin) {
+
+		// if existing reservation is in CREATED state, then it has no resources -> No need to compare.
+		if (existingReservationAdmin.getState() == ReservationState.CREATED)
+			return true;
+
+		for (IRootResource reservationResource : reservationToCompareAdmin.getResources())
+			if (existingReservationAdmin.getResources().contains(reservationResource))
+				if (periodsOverlap(existingReservationAdmin.getPeriod(), reservationToCompareAdmin.getPeriod()))
+					return false;
+
+		return true;
+
+	}
+}

--- a/extensions/network/network.impl/src/test/java/org/mqnaas/network/impl/reservation/CreateAndCancelReservationTest.java
+++ b/extensions/network/network.impl/src/test/java/org/mqnaas/network/impl/reservation/CreateAndCancelReservationTest.java
@@ -1,0 +1,514 @@
+package org.mqnaas.network.impl.reservation;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import net.i2cat.dana.mqnaas.capability.reservation.IReservationCapability;
+import net.i2cat.dana.mqnaas.capability.reservation.model.Reservation;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.mqnaas.core.api.Endpoint;
+import org.mqnaas.core.api.IResource;
+import org.mqnaas.core.api.IRootResource;
+import org.mqnaas.core.api.IService;
+import org.mqnaas.core.api.IServiceMetaData;
+import org.mqnaas.core.api.IServiceProvider;
+import org.mqnaas.core.api.RootResourceDescriptor;
+import org.mqnaas.core.api.Specification;
+import org.mqnaas.core.api.Specification.Type;
+import org.mqnaas.core.api.exceptions.ApplicationActivationException;
+import org.mqnaas.core.api.exceptions.CapabilityNotFoundException;
+import org.mqnaas.core.api.exceptions.ServiceExecutionSchedulerException;
+import org.mqnaas.core.api.exceptions.ServiceNotFoundException;
+import org.mqnaas.core.api.scheduling.IServiceExecutionScheduler;
+import org.mqnaas.core.api.scheduling.ServiceExecution;
+import org.mqnaas.core.api.scheduling.Trigger;
+import org.mqnaas.core.impl.RootResource;
+import org.mqnaas.general.test.helpers.reflection.ReflectionTestHelper;
+import org.mqnaas.network.api.request.Period;
+import org.mqnaas.network.api.reservation.IReservationAdministration;
+import org.mqnaas.network.api.reservation.IReservationAdministration.ReservationState;
+import org.mqnaas.network.api.reservation.IReservationPerformer;
+import org.mqnaas.network.api.reservation.ReservationResource;
+import org.mqnaas.network.api.reservation.ResourceReservationException;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+/**
+ * 
+ * @author Adrián Roselló Rey (i2CAT)
+ *
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(ReservationManagement.class)
+public class CreateAndCancelReservationTest {
+
+	private ReservationManagement	reservationCapability;
+
+	IServiceExecutionScheduler		serviceExecutionScheduler;
+	IServiceProvider				serviceProvider;
+
+	IReservationAdministration		reservationAdministrationCapability;
+
+	IReservationPerformer			mockedReservationPerformer;
+
+	@Before
+	public void prepareTest() throws SecurityException, NoSuchMethodException, Exception {
+
+		// partial mock the reservation capability
+		reservationCapability = PowerMockito.mock(ReservationManagement.class);
+		PowerMockito.doCallRealMethod().when(reservationCapability).createReservation();
+		PowerMockito.doCallRealMethod().when(reservationCapability)
+				.planReservation(Mockito.any(ReservationResource.class), Mockito.anySet(), Mockito.any(Period.class));
+		PowerMockito.doCallRealMethod().when(reservationCapability).cancelPlannedReservation(Mockito.any(ReservationResource.class));
+		PowerMockito.doCallRealMethod().when(reservationCapability).getReservations();
+		PowerMockito.doCallRealMethod().when(reservationCapability, "getCurrentDate");
+		PowerMockito.doCallRealMethod().when(reservationCapability).activate();
+		PowerMockito.doCallRealMethod().when(reservationCapability).getReservations(Mockito.any(ReservationState.class));
+
+		// mock scheduler capability
+		serviceExecutionScheduler = PowerMockito.mock(IServiceExecutionScheduler.class);
+		ReflectionTestHelper.injectPrivateField(reservationCapability, serviceExecutionScheduler, "serviceExecutionScheduler");
+
+		// inject and mock service provider
+		serviceProvider = PowerMockito.mock(IServiceProvider.class);
+		ReflectionTestHelper.injectPrivateField(reservationCapability, serviceProvider, "serviceProvider");
+		Mockito.when(serviceProvider.getService(Mockito.any(IResource.class), Mockito.anyString(), Mockito.<Class> anyVararg())).thenReturn(
+				new MockService());
+
+		// inject resource
+		IResource resource = new RootResource(RootResourceDescriptor.create(new Specification(Type.NETWORK)));
+		ReflectionTestHelper.injectPrivateField(reservationCapability, resource, "resource");
+
+		// inject dummy performerCapability
+		mockedReservationPerformer = new dummyReservationPerformer();
+		ReflectionTestHelper.injectPrivateField(reservationCapability, mockedReservationPerformer, "reservationPerformer");
+
+		reservationCapability.activate();
+
+	}
+
+	/**
+	 * <p>
+	 * Test checks the {@link IReservationCapability#createReservation(Reservation)} method. It tries to create a reservation with an unvalid period,
+	 * which should launch an {@link IllegalArgumentException}
+	 * </p>
+	 * 
+	 * @throws Exception
+	 */
+	@Test(expected = IllegalArgumentException.class)
+	public void planReservationForThePast() throws Exception {
+
+		Date startDate = new Date(System.currentTimeMillis() - 10000000L);
+		Date endDate = new Date(System.currentTimeMillis() + 5000L);
+
+		Set<IRootResource> rootresources = generateSampleResources();
+
+		ReservationResource reservation = (ReservationResource) reservationCapability.createReservation();
+
+		reservationCapability.planReservation(reservation, rootresources, new Period(startDate, endDate));
+	}
+
+	/**
+	 * <p>
+	 * Test checks the {@link IReservationCapability#createReservation(Reservation)} method. It tries to reserve unavaialble devices in a specific
+	 * period, which should launch a {@link ResourceReservationException}
+	 * </p>
+	 * 
+	 * @throws Exception
+	 */
+	@Test(expected = ResourceReservationException.class)
+	public void reserveUnavailableDevices() throws Exception {
+
+		Date startDate = new Date(System.currentTimeMillis());
+		Date endDate = new Date(System.currentTimeMillis() + 5000L);
+
+		Set<IRootResource> rootresources = generateSampleResources();
+
+		ReservationResource reservation = (ReservationResource) reservationCapability.createReservation();
+
+		// create custom ReservationAdministration - used by serviceProvider
+		reservationAdministrationCapability = new ReservationAdministration();
+		reservationAdministrationCapability.setResources(generateSampleResources());
+		reservationAdministrationCapability.setPeriod(new Period(startDate, endDate));
+
+		PowerMockito.doThrow(new ResourceReservationException()).when(reservationCapability, "checkResourcesAreAvailable",
+				Mockito.eq(reservation));
+
+		Mockito.when(serviceProvider.getCapability(Mockito.eq(reservation), Mockito.eq(IReservationAdministration.class))).thenReturn(
+				reservationAdministrationCapability);
+
+		reservationCapability.planReservation(reservation, rootresources, new Period(startDate, endDate));
+
+	}
+
+	/**
+	 * <p>
+	 * Test checks the {@link IReservationCapability#createReservation(Reservation)} method. Reservation should be scheduled, according to the
+	 * reservation period. Test checks:
+	 * <ul>
+	 * <li>Reservation is created</li>
+	 * <li>Reservation is in planned state.</li>
+	 * <li>{@link IServiceExecutionScheduler} is called to schedule the reservation execution.</li>
+	 * <li>{@link IServiceProvider} is called to get the service to be executed by the <code>IServiceExecutionScheduler</code></li>
+	 * </ul>
+	 * </p>
+	 * 
+	 * @throws IllegalAccessException
+	 * 
+	 * @throws CapabilityNotFoundException
+	 * @throws URISyntaxException
+	 * @throws InstantiationException
+	 * @throws ApplicationActivationException
+	 * @throws ResourceReservationException
+	 * @throws ServiceNotFoundException
+	 * @throws ServiceExecutionSchedulerException
+	 * 
+	 * @throws Exception
+	 */
+	@Test
+	public void createReservationToBeScheduled() throws InstantiationException, IllegalAccessException, URISyntaxException,
+			ApplicationActivationException, CapabilityNotFoundException, ResourceReservationException, ServiceNotFoundException,
+			ServiceExecutionSchedulerException {
+
+		// create period dates
+		Date startDate = new Date(System.currentTimeMillis() + 100000L);
+		Date endDate = new Date(System.currentTimeMillis() + 200000L);
+
+		// create custom ReservationAdministration that will be "bound" to new reservation resource
+		reservationAdministrationCapability = new ReservationAdministration();
+		reservationAdministrationCapability.setResources(generateSampleResources());
+		reservationAdministrationCapability.setPeriod(new Period(startDate, endDate));
+
+		// generate resources to be reserved
+		Set<IRootResource> rootresources = generateSampleResources();
+
+		// REAL METHOD - create reservation
+		Assert.assertTrue(reservationCapability.getReservations().isEmpty());
+		ReservationResource reservationResource = (ReservationResource) reservationCapability.createReservation();
+		Assert.assertEquals(1, reservationCapability.getReservations().size());
+
+		ReservationResource existingReservation = (ReservationResource) reservationCapability.getReservations().iterator().next();
+		Assert.assertNotNull(existingReservation);
+
+		// manually "inject" and initialize the ReservationAdministration capability for this new reservation
+		Mockito.when(serviceProvider.getCapability(Mockito.eq(reservationResource), Mockito.eq(IReservationAdministration.class))).thenReturn(
+				reservationAdministrationCapability);
+		ReflectionTestHelper.injectPrivateField(reservationAdministrationCapability, reservationResource, "resource");
+		reservationAdministrationCapability.activate();
+
+		// check it's in CREATED state
+		Assert.assertEquals(ReservationState.CREATED, reservationAdministrationCapability.getState());
+
+		// REAL METHOD - plan the reservation
+		reservationCapability.planReservation(reservationResource, rootresources, new Period(startDate, endDate));
+
+		// check reservation was scheduled and it's in PLANNED state
+		Mockito.verify(serviceProvider, Mockito.times(1)).getService(Mockito.any(IResource.class), Mockito.eq("performReservation"),
+				Mockito.<Class> anyVararg());
+
+		Mockito.verify(serviceExecutionScheduler, Mockito.times(1)).schedule(Mockito.any(ServiceExecution.class));
+		Assert.assertEquals(ReservationState.PLANNED, reservationAdministrationCapability.getState());
+
+	}
+
+	/**
+	 * <p>
+	 * Test checks the {@link IReservationCapability#createReservation(Reservation)} method. Reservation should be immediately executed, according to
+	 * the reservation period. Test checks:
+	 * <ul>
+	 * <li>Reservation is created</li>
+	 * <li>Reservation is in planned state.</li>
+	 * <li>{@link IServiceExecutionScheduler} is called to schedule the reservation execution.</li>
+	 * <li>{@link IServiceProvider} is called to get the service to be executed by the <code>IServiceExecutionScheduler</code></li>
+	 * </ul>
+	 * </p>
+	 * 
+	 * @throws CapabilityNotFoundException
+	 * @throws URISyntaxException
+	 * @throws InstantiationException
+	 * @throws ApplicationActivationException
+	 * 
+	 * @throws Exception
+	 */
+	@Test
+	public void createReservationImmediately() throws SecurityException, IllegalArgumentException, IllegalAccessException,
+			ResourceReservationException, ServiceNotFoundException, ServiceExecutionSchedulerException, CapabilityNotFoundException,
+			InstantiationException, URISyntaxException, ApplicationActivationException {
+
+		// create period dates
+		Date startDate = new Date(System.currentTimeMillis());
+		Date endDate = new Date(System.currentTimeMillis() + 200000L);
+
+		// create custom ReservationAdministration that will be "bound" to new reservation resource
+		reservationAdministrationCapability = new ReservationAdministration();
+		reservationAdministrationCapability.setResources(generateSampleResources());
+		reservationAdministrationCapability.setPeriod(new Period(startDate, endDate));
+
+		// generate resources to be reserved
+		Set<IRootResource> rootresources = generateSampleResources();
+
+		// REAL METHOD - create reservation
+		Assert.assertTrue(reservationCapability.getReservations().isEmpty());
+		ReservationResource reservationResource = (ReservationResource) reservationCapability.createReservation();
+		Assert.assertEquals(1, reservationCapability.getReservations().size());
+
+		ReservationResource existingReservation = (ReservationResource) reservationCapability.getReservations().iterator().next();
+		Assert.assertNotNull(existingReservation);
+
+		// manually "inject" and initialize the ReservationAdministration capability for this new reservation
+		Mockito.when(serviceProvider.getCapability(Mockito.eq(reservationResource), Mockito.eq(IReservationAdministration.class))).thenReturn(
+				reservationAdministrationCapability);
+		ReflectionTestHelper.injectPrivateField(reservationAdministrationCapability, reservationResource, "resource");
+		reservationAdministrationCapability.activate();
+
+		// check it's in CREATED state
+		Assert.assertEquals(ReservationState.CREATED, reservationAdministrationCapability.getState());
+
+		// REAL METHOD - plan the reservation
+		reservationCapability.planReservation(reservationResource, rootresources, new Period(startDate, endDate));
+
+		// check reservation was not scheduled and it's in RESERVED state
+
+		Mockito.verify(serviceProvider, Mockito.times(0)).getService(Mockito.any(IResource.class), Mockito.eq("performReservation"),
+				Mockito.<Class> anyVararg());
+
+		Mockito.verify(serviceExecutionScheduler, Mockito.times(0)).schedule(Mockito.any(ServiceExecution.class));
+		Assert.assertEquals(ReservationState.RESERVED, reservationAdministrationCapability.getState());
+
+	}
+
+	/**
+	 * <p>
+	 * Test checks the {@link IReservationCapability#cancelReservation(Reservation)} method. Test tries to cancel an unexisting reservation, which
+	 * should fails with a {@link ResourceReservationException}
+	 * </p>
+	 * 
+	 * @throws Exception
+	 */
+	@Test(expected = ResourceReservationException.class)
+	public void cancelUnexistingReservation() throws SecurityException, IllegalArgumentException, IllegalAccessException,
+			ResourceReservationException {
+
+		ReservationResource notExistingReservation = new ReservationResource();
+
+		reservationCapability.cancelPlannedReservation(notExistingReservation);
+	}
+
+	/**
+	 * <p>
+	 * Test checks the {@link IReservationCapability#cancelReservation(Reservation)} method. Test cancels a scheduled reservation, so it checks:
+	 * <ul>
+	 * <li>The reservation exists before executing the method</li>
+	 * <li>The reservation does not exist after executing the method</li>
+	 * <li>The {@link IServiceExecutionScheduler} has been called in order to cancel the scheduled reservation</li>
+	 * 
+	 * </ul>
+	 * </p>
+	 * 
+	 * @throws URISyntaxException
+	 * @throws InstantiationException
+	 * @throws CapabilityNotFoundException
+	 * 
+	 * @throws Exception
+	 */
+	@Test
+	public void cancelPlannedReservation1() throws SecurityException, IllegalArgumentException, IllegalAccessException,
+			ResourceReservationException, ServiceExecutionSchedulerException, InstantiationException, URISyntaxException, CapabilityNotFoundException {
+
+		Date startDate = new Date(System.currentTimeMillis());
+		Date endDate = new Date(System.currentTimeMillis() + 200000L);
+
+		// create custom ReservationAdministration that will be "bound" to new reservation resource
+		reservationAdministrationCapability = new ReservationAdministration();
+		reservationAdministrationCapability.setResources(generateSampleResources());
+		reservationAdministrationCapability.setPeriod(new Period(startDate, endDate));
+		reservationAdministrationCapability.setState(ReservationState.PLANNED);
+
+		// manually create a reservation
+		ReservationResource reservation = new ReservationResource();
+
+		// initialize reservations with generated one
+		Set<ReservationResource> reservations = new HashSet<ReservationResource>();
+		reservations.add(reservation);
+		ReflectionTestHelper.injectPrivateField(reservationCapability, reservations, "reservations");
+
+		Map<ReservationResource, ServiceExecution> reservationsServicesExeceutions = new ConcurrentHashMap<ReservationResource, ServiceExecution>();
+		ServiceExecution se = new ServiceExecution(new MockService(), new dummyTrigger());
+		reservationsServicesExeceutions.put(reservation, se);
+		ReflectionTestHelper.injectPrivateField(reservationCapability, reservationsServicesExeceutions, "reservationsServicesExeceutions");
+
+		// check we injected it correctly ;)
+		Assert.assertEquals(1, reservationCapability.getReservations().size());
+
+		// manually "inject" and initialize the ReservationAdministration capability for this new reservation
+		Mockito.when(serviceProvider.getCapability(Mockito.eq(reservation), Mockito.eq(IReservationAdministration.class))).thenReturn(
+				reservationAdministrationCapability);
+		ReflectionTestHelper.injectPrivateField(reservationAdministrationCapability, reservation, "resource");
+
+		// REAL METHOD - call planned reservation
+		Assert.assertTrue(reservationCapability.getReservations(ReservationState.CANCELLED).isEmpty());
+		reservationCapability.cancelPlannedReservation(reservation);
+
+		// check it was canceled
+		Assert.assertFalse(reservationCapability.getReservations().isEmpty());
+		Mockito.verify(serviceExecutionScheduler, Mockito.times(1)).cancel(Mockito.eq(se));
+		Assert.assertFalse(reservationCapability.getReservations(ReservationState.CANCELLED).isEmpty());
+		Assert.assertEquals(ReservationState.CANCELLED, reservationAdministrationCapability.getState());
+
+	}
+
+	/**
+	 * <p>
+	 * Test checks the {@link IReservationCapability#cancelReservation(Reservation)} method. Test cancels a planned reservation, so it checks:
+	 * <ul>
+	 * <li>The reservation exists before executing the method</li>
+	 * <li>The reservation does not exist after executing the method</li>
+	 * <li>The {@link IServiceExecutionScheduler} has not been called</li>
+	 * </ul>
+	 * Take into account that the test does not check if the reservation has been removed, since it's done by the
+	 * {@link IReservationCapability#releaseReservation(Reservation)} method (and it's mocked!)
+	 * </p>
+	 * 
+	 * @throws CapabilityNotFoundException
+	 * @throws URISyntaxException
+	 * @throws InstantiationException
+	 * 
+	 * @throws Exception
+	 */
+	@Test
+	public void cancelPerformedReservation() throws SecurityException, IllegalArgumentException, IllegalAccessException,
+			ResourceReservationException, ServiceExecutionSchedulerException, CapabilityNotFoundException, InstantiationException, URISyntaxException {
+
+		Date startDate = new Date(System.currentTimeMillis());
+		Date endDate = new Date(System.currentTimeMillis() + 200000L);
+
+		// create custom ReservationAdministration that will be "bound" to new reservation resource
+		reservationAdministrationCapability = new ReservationAdministration();
+		reservationAdministrationCapability.setResources(generateSampleResources());
+		reservationAdministrationCapability.setPeriod(new Period(startDate, endDate));
+		reservationAdministrationCapability.setState(ReservationState.RESERVED);
+
+		// manually create a reservation
+		ReservationResource reservation = new ReservationResource();
+
+		// initialize reservations with generated one
+		Set<ReservationResource> reservations = new HashSet<ReservationResource>();
+		reservations.add(reservation);
+		ReflectionTestHelper.injectPrivateField(reservationCapability, reservations, "reservations");
+
+		Map<ReservationResource, ServiceExecution> reservationsServicesExeceutions = new ConcurrentHashMap<ReservationResource, ServiceExecution>();
+		ServiceExecution se = new ServiceExecution(new MockService(), new dummyTrigger());
+		reservationsServicesExeceutions.put(reservation, se);
+		ReflectionTestHelper.injectPrivateField(reservationCapability, reservationsServicesExeceutions, "reservationsServicesExeceutions");
+
+		// check we injected it correctly ;)
+		Assert.assertEquals(1, reservationCapability.getReservations().size());
+
+		// manually "inject" and initialize the ReservationAdministration capability for this new reservation
+		Mockito.when(serviceProvider.getCapability(Mockito.eq(reservation), Mockito.eq(IReservationAdministration.class))).thenReturn(
+				reservationAdministrationCapability);
+		ReflectionTestHelper.injectPrivateField(reservationAdministrationCapability, reservation, "resource");
+
+		// REAL METHOD - call planned reservation
+		reservationCapability.cancelPlannedReservation(reservation);
+
+		// check it was canceled
+		Assert.assertFalse(reservationCapability.getReservations().isEmpty());
+		Assert.assertFalse(reservationCapability.getReservations(ReservationState.CANCELLED).isEmpty());
+		Assert.assertEquals(ReservationState.CANCELLED, reservationAdministrationCapability.getState());
+
+		Mockito.verify(serviceExecutionScheduler, Mockito.times(0)).cancel(Mockito.eq(se));
+
+	}
+
+	private Set<IRootResource> generateSampleResources() throws InstantiationException, IllegalAccessException, URISyntaxException {
+		IRootResource resource1 = new RootResource(RootResourceDescriptor.create(new Specification(Type.TSON),
+				Arrays.asList(new Endpoint(new URI("http://localhost:8182")))));
+		IRootResource resource2 = new RootResource(RootResourceDescriptor.create(new Specification(Type.TSON),
+				Arrays.asList(new Endpoint(new URI("http://localhost:8182")))));
+
+		Set<IRootResource> rootResources = new HashSet<IRootResource>();
+
+		rootResources.add(resource1);
+		rootResources.add(resource2);
+
+		return rootResources;
+
+	}
+
+	class MockService implements IService {
+
+		@Override
+		public IResource getResource() {
+			// TODO Auto-generated method stub
+			return null;
+		}
+
+		@Override
+		public IServiceMetaData getMetadata() {
+			// TODO Auto-generated method stub
+			return null;
+		}
+
+		@Override
+		public String getId() {
+			// TODO Auto-generated method stub
+			return null;
+		}
+
+	}
+
+	class dummyReservationPerformer implements IReservationPerformer {
+
+		@Override
+		public void performReservation(ReservationResource reservation) {
+			try {
+				serviceProvider.getCapability(reservation, IReservationAdministration.class).setState(ReservationState.RESERVED);
+			} catch (CapabilityNotFoundException e) {
+				// TODO Auto-generated catch block
+				e.printStackTrace();
+			}
+
+		}
+
+		@Override
+		public void cancelReservation(ReservationResource reservation) {
+			try {
+				serviceProvider.getCapability(reservation, IReservationAdministration.class).setState(ReservationState.CANCELLED);
+			} catch (CapabilityNotFoundException e) {
+				// TODO Auto-generated catch block
+				e.printStackTrace();
+			}
+		}
+
+	}
+
+	class dummyTrigger implements Trigger {
+
+		@Override
+		public Date getEndDate() {
+			// TODO Auto-generated method stub
+			return null;
+		}
+
+		@Override
+		public Date getStartDate() {
+			// TODO Auto-generated method stub
+			return null;
+		}
+
+	}
+
+}

--- a/extensions/network/network.impl/src/test/java/org/mqnaas/network/impl/reservation/ReservationManagementTest.java
+++ b/extensions/network/network.impl/src/test/java/org/mqnaas/network/impl/reservation/ReservationManagementTest.java
@@ -1,0 +1,78 @@
+package org.mqnaas.network.impl.reservation;
+
+import java.util.Date;
+import java.util.HashSet;
+import java.util.Set;
+
+import net.i2cat.dana.mqnaas.capability.reservation.impl.ReservationCapability;
+import net.i2cat.dana.mqnaas.capability.reservation.model.Device;
+import net.i2cat.dana.mqnaas.capability.reservation.model.Reservation;
+import net.i2cat.dana.mqnaas.capability.reservation.model.ReservationState;
+import net.i2cat.dana.mqnaas.capability.reservation.utils.ModelUtils;
+
+import org.mqnaas.core.api.IResource;
+import org.mqnaas.core.api.IRootResource;
+import org.mqnaas.core.api.IService;
+import org.mqnaas.core.api.IServiceMetaData;
+import org.mqnaas.core.api.Specification.Type;
+import org.mqnaas.network.api.request.Period;
+
+/**
+ * 
+ * @author Adrián Roselló Rey (i2CAT)
+ *
+ */
+public abstract class ReservationManagementTest {
+
+	protected static final String	DEVICE_ID_1	= "device01";
+	protected static final String	DEVICE_ID_2	= "device02";
+	protected static final String	DEVICE_ID_3	= "device03";
+	protected static final String	SCOPE_NITOS	= "nitos";
+
+	protected ReservationCapability	reservationCapability;
+
+	class MockService implements IService {
+
+		@Override
+		public IResource getResource() {
+			// TODO Auto-generated method stub
+			return null;
+		}
+
+		@Override
+		public IServiceMetaData getMetadata() {
+			// TODO Auto-generated method stub
+			return null;
+		}
+
+		@Override
+		public String getId() {
+			// TODO Auto-generated method stub
+			return null;
+		}
+
+	}
+
+	protected Reservation generateReservation(Date startDate, Date endDate, ReservationState reservationState) {
+
+		Period period = new Period(startDate, endDate);
+
+		Set<Device> devices = generateSampleDeviceSet();
+
+		return ModelUtils.generateReservation(devices, new HashSet<IRootResource>(), period, reservationState);
+	}
+
+	protected Set<Device> generateSampleDeviceSet() {
+
+		Device device1 = ModelUtils.generateDevice(DEVICE_ID_1, Type.OF_SWITCH, SCOPE_NITOS);
+		Device device2 = ModelUtils.generateDevice(DEVICE_ID_2, Type.OF_SWITCH, SCOPE_NITOS);
+		Device device3 = ModelUtils.generateDevice(DEVICE_ID_3, Type.OF_SWITCH, "");
+
+		Set<Device> devices = new HashSet<Device>();
+		devices.add(device1);
+		devices.add(device2);
+		devices.add(device3);
+
+		return devices;
+	}
+}

--- a/extensions/network/network.impl/src/test/java/org/mqnaas/network/impl/reservation/ReservationUtilsTest.java
+++ b/extensions/network/network.impl/src/test/java/org/mqnaas/network/impl/reservation/ReservationUtilsTest.java
@@ -1,0 +1,152 @@
+package org.mqnaas.network.impl.reservation;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mqnaas.core.api.Endpoint;
+import org.mqnaas.core.api.IRootResource;
+import org.mqnaas.core.api.RootResourceDescriptor;
+import org.mqnaas.core.api.Specification;
+import org.mqnaas.core.api.Specification.Type;
+import org.mqnaas.core.impl.RootResource;
+import org.mqnaas.network.api.request.Period;
+import org.mqnaas.network.api.reservation.IReservationAdministration;
+
+/**
+ * <p>
+ * Test for {@link ReservationUtils} class.
+ * </p>
+ * 
+ * @author Adrián Roselló Rey (i2CAT)
+ *
+ */
+public class ReservationUtilsTest {
+
+	private IRootResource	resource1;
+	private IRootResource	resource2;
+
+	@Before
+	public void prepareTest() throws InstantiationException, IllegalAccessException, URISyntaxException {
+
+		resource1 = new RootResource(RootResourceDescriptor.create(new Specification(Type.TSON),
+				Arrays.asList(new Endpoint(new URI("http://localhost:8182")))));
+		resource1 = new RootResource(RootResourceDescriptor.create(new Specification(Type.TSON),
+				Arrays.asList(new Endpoint(new URI("http://localhost:8183")))));
+	}
+
+	/**
+	 * Test checks the {@link ReservationUtils#periodsOverlap(Period, Period)} method with different periods combinations.
+	 */
+	@Test
+	public void periodsOverlapTest() {
+
+		long currentTime = System.currentTimeMillis();
+
+		// startDate2 < endDate2 < starDate1 < endDate1 -> FALSE
+
+		Period period1 = new Period(new Date(currentTime), new Date(currentTime + 5000L));
+		Period period2 = new Period(new Date(currentTime - 6000L), new Date(currentTime - 5000L));
+		Assert.assertFalse(ReservationUtils.periodsOverlap(period1, period2));
+
+		// startDate1 < endDate1 < starDate2 < endDate2 -> FALSE
+
+		period1 = new Period(new Date(currentTime), new Date(currentTime + 5000L));
+		period2 = new Period(new Date(currentTime + 10000L), new Date(currentTime + 15000L));
+		Assert.assertFalse(ReservationUtils.periodsOverlap(period1, period2));
+
+		// strartDate2 < startDate1 < endDate1 < endDate2 -> TRUE
+
+		period1 = new Period(new Date(currentTime), new Date(currentTime + 15000L));
+		period2 = new Period(new Date(currentTime + 5000L), new Date(currentTime + 10000L));
+		Assert.assertTrue(ReservationUtils.periodsOverlap(period1, period2));
+
+		// strartDate2 < startDate1 < endDate2 < endDate1 -> TRUE
+
+		period1 = new Period(new Date(currentTime), new Date(currentTime + 10000L));
+		period2 = new Period(new Date(currentTime + 5000L), new Date(currentTime + 15000L));
+		Assert.assertTrue(ReservationUtils.periodsOverlap(period1, period2));
+
+		// strartDate1 < startDate2 < endDate1 < endDate2 -> TRUE
+
+		period1 = new Period(new Date(currentTime + 5000L), new Date(currentTime + 15000L));
+		period2 = new Period(new Date(currentTime), new Date(currentTime + 10000L));
+		Assert.assertTrue(ReservationUtils.periodsOverlap(period1, period2));
+
+		// startDate1 = startDate2
+		period1 = new Period(new Date(currentTime), new Date(currentTime + 15000L));
+		period2 = new Period(new Date(currentTime), new Date(currentTime + 10000L));
+		Assert.assertTrue(ReservationUtils.periodsOverlap(period1, period2));
+
+		// endDate1 = endDate2
+		period1 = new Period(new Date(currentTime + 5000), new Date(currentTime + 10000L));
+		period2 = new Period(new Date(currentTime), new Date(currentTime + 10000L));
+		Assert.assertTrue(ReservationUtils.periodsOverlap(period1, period2));
+
+		// endDateX = startDateY
+		period1 = new Period(new Date(currentTime), new Date(currentTime + 5000L));
+		period2 = new Period(new Date(currentTime + 5000L), new Date(currentTime + 10000L));
+		Assert.assertTrue(ReservationUtils.periodsOverlap(period1, period2));
+
+	}
+
+	/**
+	 * Test checks {@link ReservationUtils#areResourcesAvailable(IReservationAdministration, IReservationAdministration) method with different
+	 * resources-periods combinations.}
+	 */
+	@Test
+	public void areResourcesAvailableTest() {
+
+		long currentTime = System.currentTimeMillis();
+
+		IReservationAdministration existingReservationAdmin = new ReservationAdministration();
+		IReservationAdministration reservationToCompareAdmin = new ReservationAdministration();
+
+		// same devices, different periods
+		Set<IRootResource> resources = new HashSet<IRootResource>();
+		resources.add(resource1);
+		resources.add(resource2);
+
+		Period existingPeriod = new Period(new Date(currentTime), new Date(currentTime + 5000L));
+		Period period = new Period(new Date(currentTime - 10000L), new Date(currentTime - 5000L));
+
+		existingReservationAdmin.setPeriod(existingPeriod);
+		existingReservationAdmin.setResources(resources);
+
+		reservationToCompareAdmin.setPeriod(period);
+		reservationToCompareAdmin.setResources(resources);
+
+		Assert.assertTrue(ReservationUtils.areResourcesAvailable(existingReservationAdmin, reservationToCompareAdmin));
+
+		// same devices, same period
+		existingPeriod = new Period(new Date(currentTime), new Date(currentTime + 10000L));
+		period = new Period(new Date(currentTime + 5000L), new Date(currentTime + 15000L));
+
+		existingReservationAdmin.setPeriod(existingPeriod);
+		reservationToCompareAdmin.setPeriod(period);
+
+		Assert.assertFalse(ReservationUtils.areResourcesAvailable(existingReservationAdmin, reservationToCompareAdmin));
+
+		// different devices, no matter period
+		resources = new HashSet<IRootResource>();
+		resources.add(resource1);
+		existingPeriod = new Period(new Date(currentTime), new Date(currentTime + 5000L));
+		existingReservationAdmin.setPeriod(existingPeriod);
+		existingReservationAdmin.setResources(resources);
+
+		resources = new HashSet<IRootResource>();
+		resources.add(resource2);
+		period = new Period(new Date(currentTime + 5000L), new Date(currentTime + 15000L));
+		reservationToCompareAdmin.setPeriod(existingPeriod);
+		reservationToCompareAdmin.setResources(resources);
+
+		Assert.assertTrue(ReservationUtils.areResourcesAvailable(existingReservationAdmin, reservationToCompareAdmin));
+
+	}
+}

--- a/extensions/network/network.impl/src/test/java/org/mqnaas/network/impl/reservation/ReservationUtilsTest.java
+++ b/extensions/network/network.impl/src/test/java/org/mqnaas/network/impl/reservation/ReservationUtilsTest.java
@@ -37,7 +37,7 @@ public class ReservationUtilsTest {
 
 		resource1 = new RootResource(RootResourceDescriptor.create(new Specification(Type.TSON),
 				Arrays.asList(new Endpoint(new URI("http://localhost:8182")))));
-		resource1 = new RootResource(RootResourceDescriptor.create(new Specification(Type.TSON),
+		resource2 = new RootResource(RootResourceDescriptor.create(new Specification(Type.TSON),
 				Arrays.asList(new Endpoint(new URI("http://localhost:8183")))));
 	}
 

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -46,6 +46,9 @@
 		<!-- Wiremock version -->
 		<wiremock.version>1.51</wiremock.version>
 		
+		<!-- Powermock version -->
+		<powermock.version>1.5.4</powermock.version>
+		
 		<!-- Javax Inject version -->
 		<javax.inject.version>1_2</javax.inject.version>
 		
@@ -127,6 +130,16 @@
 				<artifactId>wiremock</artifactId>
 				<version>${wiremock.version}</version>
 				<scope>test</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.powermock</groupId>
+				<artifactId>powermock-api-mockito</artifactId>
+				<version>${powermock.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.powermock</groupId>
+				<artifactId>powermock-module-junit4</artifactId>
+				<version>${powermock.version}</version>
 			</dependency>
 			<!-- IO Utils -->
 			<dependency>


### PR DESCRIPTION
This pull request ist the first one of a set of pull requests refactoring the old reservation capability.

Three new capabilities have been created:
- IReservationManagement: Reservations are resources, so they need a management capability.
- IReservationPlanner: Plans a reservation of resources for a specific period of time.
- IReservationPerformer: Responsible of performing the reservation of resources planned by the IReservationPlanner capability.

ReservationManagement is a capability implementing the IReservationManagement and IReservationPlanner. It's generic and can be bound to any network.

In the other hand, IReservationPerformer may require specific implementations for each type of network. IReservationPerformer is NOT implemented in this pull request.

The ReservationResource contains a binding capability: the IReservationAdministration. It provides methods to specify the resources to be reserved, as well as the reservation state and the period of the reservation.

In order to make a reservation the following procedure must be followed:
```java
makeReservation(IReservationManagement mgmt, IReservationPlanner planner, 
Time when, IResource... toBeReserved ) {
    IResource res = mgmt.createReservation();
    IReservationAdministration admin = getCapability(res, ReservationAdministration.class);
    // add resources to res using admin.addResource()...
    planner.planReservation(res, when); 
}
```

Fixes following tasks:
http://jira.i2cat.net/browse/OPENNAAS-1511
http://jira.i2cat.net/browse/OPENNAAS-1512
http://jira.i2cat.net/browse/OPENNAAS-1536