### PR TITLE
IAttributeStore contains String used to store external resource id.

### DIFF
--- a/core.api/src/main/java/org/mqnaas/core/api/IAttributeStore.java
+++ b/core.api/src/main/java/org/mqnaas/core/api/IAttributeStore.java
@@ -7,6 +7,9 @@ package org.mqnaas.core.api;
  */
 public interface IAttributeStore extends ICapability {
 
+	/**
+	 * This static can be used by all modules defining a map between an OpenNaaS {@link IResource} and an external component.
+	 */
 	static final String	RESOURCE_EXTERNAL_ID	= "resource.external.id";
 
 	String getAttribute(String name);

--- a/core.api/src/main/java/org/mqnaas/core/api/IAttributeStore.java
+++ b/core.api/src/main/java/org/mqnaas/core/api/IAttributeStore.java
@@ -7,6 +7,8 @@ package org.mqnaas.core.api;
  */
 public interface IAttributeStore extends ICapability {
 
+	static final String	RESOURCE_EXTERNAL_ID	= "resource.external.id";
+
 	String getAttribute(String name);
 
 	void setAttribute(String name, String value);


### PR DESCRIPTION
This static must be defined somewhere accesible by all resources. I suggest to add it in the interface. since its purpose its to read and/or put this attribute to the AttributeStore capability.