### PR TITLE
Refactor/reservation capab

### DIFF
--- a/core/src/main/java/org/mqnaas/core/impl/AttributeStore.java
+++ b/core/src/main/java/org/mqnaas/core/impl/AttributeStore.java
@@ -6,7 +6,10 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.mqnaas.core.api.IAttributeStore;
 import org.mqnaas.core.api.IResource;
 import org.mqnaas.core.api.IRootResource;
+import org.mqnaas.core.api.annotations.Resource;
 import org.mqnaas.core.api.exceptions.ApplicationActivationException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Implementation of {@link IAttributeStore} backed by a {@link ConcurrentHashMap} bound to all resources except the core.
@@ -15,7 +18,12 @@ import org.mqnaas.core.api.exceptions.ApplicationActivationException;
  */
 public class AttributeStore implements IAttributeStore {
 
+	private static final Logger	log	= LoggerFactory.getLogger(AttributeStore.class);
+
 	private Map<String, String>	attributes;
+
+	@Resource
+	IResource					resource;
 
 	public static boolean isSupporting(IResource resource) {
 		return true;
@@ -37,11 +45,17 @@ public class AttributeStore implements IAttributeStore {
 
 	@Override
 	public void activate() throws ApplicationActivationException {
+		log.info("Initializing AttributeStore capability for resource " + resource.getId());
 		attributes = new ConcurrentHashMap<String, String>();
+		log.info("Initialized AttributeStore capability for resource " + resource.getId());
+
 	}
 
 	@Override
 	public void deactivate() {
+		log.info("Removing AttributeStore capability from resource " + resource.getId());
+		log.info("Removed AttributeStore capability from resource " + resource.getId());
+
 	}
 
 }

--- a/extensions/network/itests/pom.xml
+++ b/extensions/network/itests/pom.xml
@@ -29,6 +29,14 @@
 			<groupId>org.mqnaas.extensions</groupId>
 			<artifactId>network.impl</artifactId>
 		</dependency>
+		
+		<!-- Nitos modules -->
+		<dependency>
+			<groupId>net.i2cat.dana.nitos</groupId>
+			<artifactId>nitos-client</artifactId>
+			<scope>test</scope>
+			<version>0.0.1-SNAPSHOT</version>
+		</dependency>
 		<!-- Tests libraries-->
 		<dependency>
 			<groupId>junit</groupId>

--- a/extensions/network/itests/src/test/java/org/mqnaas/extensions/network/itests/NetworkManagementTest.java
+++ b/extensions/network/itests/src/test/java/org/mqnaas/extensions/network/itests/NetworkManagementTest.java
@@ -123,6 +123,10 @@ public class NetworkManagementTest {
 				// add network features
 				KarafDistributionOption.features(CoreOptions.maven().groupId("org.mqnaas.extensions").artifactId("network").classifier("features")
 						.type("xml").version("0.0.1-SNAPSHOT"), "network"),
+				// add nitos featuress
+				KarafDistributionOption.features(CoreOptions.maven().groupId("net.i2cat.dana.nitos").artifactId("mqnaas-nitos")
+						.classifier("features")
+						.type("xml").version("0.0.1-SNAPSHOT"), "nitos"),
 				// add tson features
 				KarafDistributionOption.features(CoreOptions.maven().groupId("net.i2cat.dana.tson").artifactId("tson").classifier("features")
 						.type("xml").version("0.0.1-SNAPSHOT"), "tson"),

--- a/extensions/network/network.api/src/main/java/org/mqnaas/network/api/reservation/IReservationPlanner.java
+++ b/extensions/network/network.api/src/main/java/org/mqnaas/network/api/reservation/IReservationPlanner.java
@@ -1,7 +1,5 @@
 package org.mqnaas.network.api.reservation;
 
-import java.util.Set;
-
 import org.mqnaas.core.api.ICapability;
 import org.mqnaas.core.api.IRootResource;
 import org.mqnaas.network.api.request.Period;
@@ -21,7 +19,7 @@ import org.mqnaas.network.api.request.Period;
  */
 public interface IReservationPlanner extends ICapability {
 
-	void planReservation(ReservationResource reservation, Set<IRootResource> resources, Period period) throws ResourceReservationException;
+	void planReservation(ReservationResource reservation) throws ResourceReservationException;
 
 	void cancelPlannedReservation(ReservationResource reservation) throws ResourceReservationException;
 

--- a/extensions/network/network.impl/pom.xml
+++ b/extensions/network/network.impl/pom.xml
@@ -30,12 +30,6 @@
 			<artifactId>network.api</artifactId>
 		</dependency>
 
-		<!-- Reservation Capability -->
-		<dependency>
-			<groupId>net.i2cat.dana.mqnaas</groupId>
-			<artifactId>reservation-capability</artifactId>
-		</dependency>
-
 		<!-- Testing -->
 		<dependency>
 			<groupId>junit</groupId>

--- a/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/reservation/ReservationManagement.java
+++ b/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/reservation/ReservationManagement.java
@@ -140,7 +140,7 @@ public class ReservationManagement implements IReservationManagement, IReservati
 		checkResourcesAreAvailable(reservation);
 
 		try {
-			reservationAdmin = serviceProvider.getCapability(reservation, IReservationAdministration.class);
+
 			reservationAdmin.setState(ReservationState.PLANNED);
 
 			if (reservationAdmin.getPeriod().getStartdate().after(new Date(System.currentTimeMillis()))) {
@@ -157,8 +157,6 @@ public class ReservationManagement implements IReservationManagement, IReservati
 			else {
 				reservationPerformer.performReservation(reservation);
 			}
-		} catch (CapabilityNotFoundException c) {
-			throw new ResourceReservationException(c);
 		} catch (ServiceNotFoundException e) {
 			log.error("Could not obtain performReservation service.", e);
 			throw new ResourceReservationException(e);

--- a/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/reservation/ReservationManagement.java
+++ b/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/reservation/ReservationManagement.java
@@ -111,10 +111,21 @@ public class ReservationManagement implements IReservationManagement, IReservati
 	 *             If given <code>resources</code> are not available during the specified <code>period</code>
 	 */
 	@Override
-	public void planReservation(ReservationResource reservation, Set<IRootResource> resources, Period period) throws ResourceReservationException {
+	public void planReservation(ReservationResource reservation) throws ResourceReservationException {
 
-		if (reservation == null || period == null || resources == null)
+		if (reservation == null)
 			throw new NullPointerException("Reservation, resources and period are required to plan a reservation.");
+
+		IReservationAdministration reservationAdmin;
+
+		try {
+			reservationAdmin = serviceProvider.getCapability(reservation, IReservationAdministration.class);
+		} catch (CapabilityNotFoundException c) {
+			throw new ResourceReservationException(c);
+		}
+
+		Set<IRootResource> resources = reservationAdmin.getResources();
+		Period period = reservationAdmin.getPeriod();
 
 		if (resources.isEmpty())
 			throw new IllegalArgumentException("You need at least one resource in order to plan a reservation");
@@ -129,7 +140,7 @@ public class ReservationManagement implements IReservationManagement, IReservati
 		checkResourcesAreAvailable(reservation);
 
 		try {
-			IReservationAdministration reservationAdmin = serviceProvider.getCapability(reservation, IReservationAdministration.class);
+			reservationAdmin = serviceProvider.getCapability(reservation, IReservationAdministration.class);
 			reservationAdmin.setState(ReservationState.PLANNED);
 
 			if (reservationAdmin.getPeriod().getStartdate().after(new Date(System.currentTimeMillis()))) {

--- a/extensions/network/network.impl/src/test/java/org/mqnaas/network/impl/reservation/ReservationManagementTest.java
+++ b/extensions/network/network.impl/src/test/java/org/mqnaas/network/impl/reservation/ReservationManagementTest.java
@@ -68,7 +68,7 @@ public class ReservationManagementTest {
 		reservationCapability = PowerMockito.mock(ReservationManagement.class);
 		PowerMockito.doCallRealMethod().when(reservationCapability).createReservation();
 		PowerMockito.doCallRealMethod().when(reservationCapability)
-				.planReservation(Mockito.any(ReservationResource.class), Mockito.anySet(), Mockito.any(Period.class));
+				.planReservation(Mockito.any(ReservationResource.class));
 		PowerMockito.doCallRealMethod().when(reservationCapability).cancelPlannedReservation(Mockito.any(ReservationResource.class));
 		PowerMockito.doCallRealMethod().when(reservationCapability).getReservations();
 		PowerMockito.doCallRealMethod().when(reservationCapability, "getCurrentDate");
@@ -115,7 +115,13 @@ public class ReservationManagementTest {
 
 		ReservationResource reservation = (ReservationResource) reservationCapability.createReservation();
 
-		reservationCapability.planReservation(reservation, rootresources, new Period(startDate, endDate));
+		reservationAdministrationCapability = new ReservationAdministration();
+		reservationAdministrationCapability.setPeriod(new Period(startDate, endDate));
+		reservationAdministrationCapability.setResources(rootresources);
+		Mockito.when(serviceProvider.getCapability(Mockito.eq(reservation), Mockito.eq(IReservationAdministration.class))).thenReturn(
+				reservationAdministrationCapability);
+
+		reservationCapability.planReservation(reservation);
 	}
 
 	/**
@@ -147,8 +153,7 @@ public class ReservationManagementTest {
 		Mockito.when(serviceProvider.getCapability(Mockito.eq(reservation), Mockito.eq(IReservationAdministration.class))).thenReturn(
 				reservationAdministrationCapability);
 
-		reservationCapability.planReservation(reservation, rootresources, new Period(startDate, endDate));
-
+		reservationCapability.planReservation(reservation);
 	}
 
 	/**
@@ -210,7 +215,7 @@ public class ReservationManagementTest {
 		Assert.assertEquals(ReservationState.CREATED, reservationAdministrationCapability.getState());
 
 		// REAL METHOD - plan the reservation
-		reservationCapability.planReservation(reservationResource, rootresources, new Period(startDate, endDate));
+		reservationCapability.planReservation(reservationResource);
 
 		// check reservation was scheduled and it's in PLANNED state
 		Mockito.verify(serviceProvider, Mockito.times(1)).getService(Mockito.any(IResource.class), Mockito.eq("performReservation"),
@@ -275,8 +280,7 @@ public class ReservationManagementTest {
 		Assert.assertEquals(ReservationState.CREATED, reservationAdministrationCapability.getState());
 
 		// REAL METHOD - plan the reservation
-		reservationCapability.planReservation(reservationResource, rootresources, new Period(startDate, endDate));
-
+		reservationCapability.planReservation(reservationResource);
 		// check reservation was not scheduled and it's in RESERVED state
 
 		Mockito.verify(serviceProvider, Mockito.times(0)).getService(Mockito.any(IResource.class), Mockito.eq("performReservation"),

--- a/extensions/network/network.impl/src/test/java/org/mqnaas/network/impl/reservation/ReservationPerformerTest.java
+++ b/extensions/network/network.impl/src/test/java/org/mqnaas/network/impl/reservation/ReservationPerformerTest.java
@@ -9,8 +9,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
-import net.i2cat.dana.nitos.reservation.exception.NitosReservationException;
-
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -99,7 +97,7 @@ public class ReservationPerformerTest {
 	 */
 	@Test
 	public void performReservationTest() throws ResourceReservationException, SecurityException, IllegalArgumentException, IllegalAccessException,
-			ServiceExecutionSchedulerException, NitosReservationException, InstantiationException, URISyntaxException, CapabilityNotFoundException {
+			ServiceExecutionSchedulerException, InstantiationException, URISyntaxException, CapabilityNotFoundException {
 
 		Date startDate = new Date(System.currentTimeMillis());
 		Date endDate = new Date(System.currentTimeMillis() + 5000L);

--- a/extensions/network/pom.xml
+++ b/extensions/network/pom.xml
@@ -40,12 +40,6 @@
 				<artifactId>network.impl</artifactId>
 				<version>${project.version}</version>
 			</dependency>
-			<!-- MQNaaS Capabilities -->
-			<dependency>
-				<groupId>net.i2cat.dana.mqnaas</groupId>
-				<artifactId>reservation-capability</artifactId>
-				<version>${mqnaas.version}</version>
-			</dependency>
 			<!-- Others -->
 			<dependency>
 				<groupId>org.apache.commons</groupId>

--- a/extensions/network/src/main/resources/features.xml
+++ b/extensions/network/src/main/resources/features.xml
@@ -3,11 +3,9 @@
 
 	<!-- MQNaaS repository -->
 	<repository>mvn:org.mqnaas/mqnaas/${mqnaas.version}/xml/features</repository>
-	<repository>mvn:net.i2cat.dana.mqnaas/reservation-capability/${mqnaas.version}/xml/features</repository>
 	<feature name="network" version="${project.version}">
 
 	    <feature version="${mqnaas.version}">mqnaas</feature>
-	    <feature version="${mqnaas.version}">reservation-capability</feature>
 	    	    
 		<feature version="${project.version}">network-api</feature>
 		<feature version="${project.version}">network-impl</feature>


### PR DESCRIPTION
This pull request is the last one of a set of pull requests refactoring the reservation capability.

The network-impl does no longer depends on the reservation-capability. In fact it didin't depend on it, so I think it was legacy code.

Please be aware that the network/itests bundles has a new dependency in its pom: nitos-client. Before this pull request, following dependency chain existed in our platform:

itests -> network.impl -> reservation-capability -> nitos-reservation-capab -> nitos-client

Since *network.impl -> reservation-capability* has been removed, the nitos-client needed to be added, since it's used to mock the NITOS response when performing a reservation. **This dependency should be fixed in the future as well**

The second goal of this pull request is to fix a conceptual error in the IReservastionPlanner. It does not need to receive period and resources as parameter, since the ReservationResource's ReservationAdminsitration capability is the one responsible of managing them.

