### PR TITLE
Software licenses

### DIFF
--- a/api.rest/src/main/java/org/mqnaas/api/APIConnector.java
+++ b/api.rest/src/main/java/org/mqnaas/api/APIConnector.java
@@ -1,5 +1,27 @@
 package org.mqnaas.api;
 
+/*
+ * #%L
+ * MQNaaS :: REST API Provider
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.mqnaas.api.exceptions.InvalidCapabilityDefinionException;
 import org.mqnaas.core.api.IApplication;
 import org.mqnaas.core.api.ICapability;

--- a/api.rest/src/main/java/org/mqnaas/api/ContentType.java
+++ b/api.rest/src/main/java/org/mqnaas/api/ContentType.java
@@ -1,5 +1,27 @@
 package org.mqnaas.api;
 
+/*
+ * #%L
+ * MQNaaS :: REST API Provider
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;

--- a/api.rest/src/main/java/org/mqnaas/api/IAPIConnector.java
+++ b/api.rest/src/main/java/org/mqnaas/api/IAPIConnector.java
@@ -1,5 +1,27 @@
 package org.mqnaas.api;
 
+/*
+ * #%L
+ * MQNaaS :: REST API Provider
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.mqnaas.api.exceptions.InvalidCapabilityDefinionException;
 import org.mqnaas.core.api.IApplication;
 import org.mqnaas.core.impl.ApplicationInstance;

--- a/api.rest/src/main/java/org/mqnaas/api/IRESTAPIProvider.java
+++ b/api.rest/src/main/java/org/mqnaas/api/IRESTAPIProvider.java
@@ -1,5 +1,27 @@
 package org.mqnaas.api;
 
+/*
+ * #%L
+ * MQNaaS :: REST API Provider
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.mqnaas.api.exceptions.InvalidCapabilityDefinionException;
 import org.mqnaas.core.api.ICapability;
 

--- a/api.rest/src/main/java/org/mqnaas/api/RESTAPIGenerator.java
+++ b/api.rest/src/main/java/org/mqnaas/api/RESTAPIGenerator.java
@@ -1,5 +1,27 @@
 package org.mqnaas.api;
 
+/*
+ * #%L
+ * MQNaaS :: REST API Provider
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Map.Entry;

--- a/api.rest/src/main/java/org/mqnaas/api/RESTAPIProvider.java
+++ b/api.rest/src/main/java/org/mqnaas/api/RESTAPIProvider.java
@@ -1,5 +1,27 @@
 package org.mqnaas.api;
 
+/*
+ * #%L
+ * MQNaaS :: REST API Provider
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.lang.reflect.Proxy;
 import java.util.HashMap;
 import java.util.Map;

--- a/api.rest/src/main/java/org/mqnaas/api/ServerFactory.java
+++ b/api.rest/src/main/java/org/mqnaas/api/ServerFactory.java
@@ -1,5 +1,27 @@
 package org.mqnaas.api;
 
+/*
+ * #%L
+ * MQNaaS :: REST API Provider
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.HashSet;

--- a/api.rest/src/main/java/org/mqnaas/api/exceptions/InvalidCapabilityDefinionException.java
+++ b/api.rest/src/main/java/org/mqnaas/api/exceptions/InvalidCapabilityDefinionException.java
@@ -1,5 +1,27 @@
 package org.mqnaas.api.exceptions;
 
+/*
+ * #%L
+ * MQNaaS :: REST API Provider
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 /**
  * An <code>InvalidCapabilityDefinionException</code> is thrown by the API publishing mechanism whenever the given capability interface is violating
  * the restrictions of the publication process.

--- a/api.rest/src/main/java/org/mqnaas/api/mapping/APIMapper.java
+++ b/api.rest/src/main/java/org/mqnaas/api/mapping/APIMapper.java
@@ -1,5 +1,27 @@
 package org.mqnaas.api.mapping;
 
+/*
+ * #%L
+ * MQNaaS :: REST API Provider
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.util.Arrays;

--- a/api.rest/src/main/java/org/mqnaas/api/mapping/MethodMapper.java
+++ b/api.rest/src/main/java/org/mqnaas/api/mapping/MethodMapper.java
@@ -1,5 +1,27 @@
 package org.mqnaas.api.mapping;
 
+/*
+ * #%L
+ * MQNaaS :: REST API Provider
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 

--- a/api.rest/src/main/java/org/mqnaas/api/providers/AbstractMessageBodyWriter.java
+++ b/api.rest/src/main/java/org/mqnaas/api/providers/AbstractMessageBodyWriter.java
@@ -1,5 +1,27 @@
 package org.mqnaas.api.providers;
 
+/*
+ * #%L
+ * MQNaaS :: REST API Provider
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 

--- a/api.rest/src/main/java/org/mqnaas/api/providers/GenericListSerializationProvider.java
+++ b/api.rest/src/main/java/org/mqnaas/api/providers/GenericListSerializationProvider.java
@@ -1,5 +1,27 @@
 package org.mqnaas.api.providers;
 
+/*
+ * #%L
+ * MQNaaS :: REST API Provider
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.io.IOException;
 import java.io.OutputStream;
 import java.lang.annotation.Annotation;

--- a/api.rest/src/main/java/org/mqnaas/api/providers/MultiMapSerializationProvider.java
+++ b/api.rest/src/main/java/org/mqnaas/api/providers/MultiMapSerializationProvider.java
@@ -1,5 +1,27 @@
 package org.mqnaas.api.providers;
 
+/*
+ * #%L
+ * MQNaaS :: REST API Provider
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.io.IOException;
 import java.io.OutputStream;
 import java.lang.annotation.Annotation;

--- a/api.rest/src/main/java/org/mqnaas/api/translators/ClassTranslator.java
+++ b/api.rest/src/main/java/org/mqnaas/api/translators/ClassTranslator.java
@@ -1,5 +1,27 @@
 package org.mqnaas.api.translators;
 
+/*
+ * #%L
+ * MQNaaS :: REST API Provider
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 public class ClassTranslator implements Translator {
 
 	@Override

--- a/api.rest/src/main/java/org/mqnaas/api/translators/Identifiable2IdTranslator.java
+++ b/api.rest/src/main/java/org/mqnaas/api/translators/Identifiable2IdTranslator.java
@@ -1,5 +1,27 @@
 package org.mqnaas.api.translators;
 
+/*
+ * #%L
+ * MQNaaS :: REST API Provider
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.mqnaas.core.api.IIdentifiable;
 
 /**

--- a/api.rest/src/main/java/org/mqnaas/api/translators/ResourceTranslator.java
+++ b/api.rest/src/main/java/org/mqnaas/api/translators/ResourceTranslator.java
@@ -1,5 +1,27 @@
 package org.mqnaas.api.translators;
 
+/*
+ * #%L
+ * MQNaaS :: REST API Provider
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;

--- a/api.rest/src/main/java/org/mqnaas/api/translators/Translator.java
+++ b/api.rest/src/main/java/org/mqnaas/api/translators/Translator.java
@@ -1,5 +1,27 @@
 package org.mqnaas.api.translators;
 
+/*
+ * #%L
+ * MQNaaS :: REST API Provider
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 /**
  * <p>
  * A Translator translates input to output.

--- a/api.rest/src/main/java/org/mqnaas/api/translators/Translators.java
+++ b/api.rest/src/main/java/org/mqnaas/api/translators/Translators.java
@@ -1,5 +1,27 @@
 package org.mqnaas.api.translators;
 
+/*
+ * #%L
+ * MQNaaS :: REST API Provider
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.lang.reflect.Array;
 import java.util.HashMap;
 import java.util.Map;

--- a/api.rest/src/main/java/org/mqnaas/api/writers/AbstractWriter.java
+++ b/api.rest/src/main/java/org/mqnaas/api/writers/AbstractWriter.java
@@ -1,5 +1,27 @@
 package org.mqnaas.api.writers;
 
+/*
+ * #%L
+ * MQNaaS :: REST API Provider
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.Map;

--- a/api.rest/src/main/java/org/mqnaas/api/writers/AnnotationParamWriter.java
+++ b/api.rest/src/main/java/org/mqnaas/api/writers/AnnotationParamWriter.java
@@ -1,5 +1,27 @@
 package org.mqnaas.api.writers;
 
+/*
+ * #%L
+ * MQNaaS :: REST API Provider
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.i2cat.utils.StringBuilderUtils;
 import org.objectweb.asm.AnnotationVisitor;
 

--- a/api.rest/src/main/java/org/mqnaas/api/writers/AnnotationWriter.java
+++ b/api.rest/src/main/java/org/mqnaas/api/writers/AnnotationWriter.java
@@ -1,5 +1,27 @@
 package org.mqnaas.api.writers;
 
+/*
+ * #%L
+ * MQNaaS :: REST API Provider
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.lang.annotation.Annotation;
 
 import org.i2cat.utils.StringBuilderUtils;

--- a/api.rest/src/main/java/org/mqnaas/api/writers/CapabilityMetaDataContainer.java
+++ b/api.rest/src/main/java/org/mqnaas/api/writers/CapabilityMetaDataContainer.java
@@ -1,5 +1,27 @@
 package org.mqnaas.api.writers;
 
+/*
+ * #%L
+ * MQNaaS :: REST API Provider
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;

--- a/api.rest/src/main/java/org/mqnaas/api/writers/EmptyVisitor.java
+++ b/api.rest/src/main/java/org/mqnaas/api/writers/EmptyVisitor.java
@@ -1,5 +1,27 @@
 package org.mqnaas.api.writers;
 
+/*
+ * #%L
+ * MQNaaS :: REST API Provider
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 /***
  * ASM: a very small and fast Java bytecode manipulation framework
  * Copyright (c) 2000-2007 INRIA, France Telecom

--- a/api.rest/src/main/java/org/mqnaas/api/writers/InterfaceWriter.java
+++ b/api.rest/src/main/java/org/mqnaas/api/writers/InterfaceWriter.java
@@ -1,5 +1,27 @@
 package org.mqnaas.api.writers;
 
+/*
+ * #%L
+ * MQNaaS :: REST API Provider
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.util.Collection;

--- a/api.rest/src/main/java/org/mqnaas/api/writers/MethodWriter.java
+++ b/api.rest/src/main/java/org/mqnaas/api/writers/MethodWriter.java
@@ -1,5 +1,27 @@
 package org.mqnaas.api.writers;
 
+/*
+ * #%L
+ * MQNaaS :: REST API Provider
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;

--- a/bundletree/itests-testbundleA/src/main/java/org/mqnaas/bundletree/itests/testbundleA/RootClass.java
+++ b/bundletree/itests-testbundleA/src/main/java/org/mqnaas/bundletree/itests/testbundleA/RootClass.java
@@ -1,5 +1,27 @@
 package org.mqnaas.bundletree.itests.testbundleA;
 
+/*
+ * #%L
+ * MQNaaS :: BundleTree :: iTests TestBundleA
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.mqnaas.core.api.ICapability;
 
 public class RootClass implements ICapability {

--- a/bundletree/itests-testbundleB/src/main/java/org/mqnaas/bundletree/itests/testbundleB/TestClassA.java
+++ b/bundletree/itests-testbundleB/src/main/java/org/mqnaas/bundletree/itests/testbundleB/TestClassA.java
@@ -1,5 +1,27 @@
 package org.mqnaas.bundletree.itests.testbundleB;
 
+/*
+ * #%L
+ * MQNaaS :: BundleTree :: iTests TestBundleB
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.mqnaas.bundletree.itests.testbundleA.RootClass;
 
 public class TestClassA extends RootClass {

--- a/bundletree/itests/src/test/java/org/mqnaas/bundletree/test/BundleGuardTest.java
+++ b/bundletree/itests/src/test/java/org/mqnaas/bundletree/test/BundleGuardTest.java
@@ -1,5 +1,27 @@
 package org.mqnaas.bundletree.test;
 
+/*
+ * #%L
+ * MQNaaS :: BundleTree :: iTests
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.io.File;
 import java.util.HashSet;
 import java.util.Set;

--- a/bundletree/itests/src/test/java/org/mqnaas/bundletree/utils/test/BundleUtilsTest.java
+++ b/bundletree/itests/src/test/java/org/mqnaas/bundletree/utils/test/BundleUtilsTest.java
@@ -1,5 +1,27 @@
 package org.mqnaas.bundletree.utils.test;
 
+/*
+ * #%L
+ * MQNaaS :: BundleTree :: iTests
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.io.File;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;

--- a/bundletree/src/main/java/org/mqnaas/bundletree/IBundleGuard.java
+++ b/bundletree/src/main/java/org/mqnaas/bundletree/IBundleGuard.java
@@ -1,5 +1,27 @@
 package org.mqnaas.bundletree;
 
+/*
+ * #%L
+ * MQNaaS :: BundleTree
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.mqnaas.core.api.ICapability;
 
 /**

--- a/bundletree/src/main/java/org/mqnaas/bundletree/IClassFilter.java
+++ b/bundletree/src/main/java/org/mqnaas/bundletree/IClassFilter.java
@@ -1,5 +1,27 @@
 package org.mqnaas.bundletree;
 
+/*
+ * #%L
+ * MQNaaS :: BundleTree
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 /**
  * Class Filter interface allowing to define an arbitrary logic to filter {@link Class}es in the method {@link #filter(Class)}.
  * 

--- a/bundletree/src/main/java/org/mqnaas/bundletree/IClassListener.java
+++ b/bundletree/src/main/java/org/mqnaas/bundletree/IClassListener.java
@@ -1,5 +1,27 @@
 package org.mqnaas.bundletree;
 
+/*
+ * #%L
+ * MQNaaS :: BundleTree
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 /**
  * Class Listener interface allowing to be registered in a {@link IBundleGuard} instance. <br/>
  * It contains two methods called back when:

--- a/bundletree/src/main/java/org/mqnaas/bundletree/exceptions/BundleNotFoundException.java
+++ b/bundletree/src/main/java/org/mqnaas/bundletree/exceptions/BundleNotFoundException.java
@@ -1,5 +1,27 @@
 package org.mqnaas.bundletree.exceptions;
 
+/*
+ * #%L
+ * MQNaaS :: BundleTree
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 /**
  * Bundle Not Found Exception
  * 

--- a/bundletree/src/main/java/org/mqnaas/bundletree/impl/BundleGuard.java
+++ b/bundletree/src/main/java/org/mqnaas/bundletree/impl/BundleGuard.java
@@ -1,5 +1,27 @@
 package org.mqnaas.bundletree.impl;
 
+/*
+ * #%L
+ * MQNaaS :: BundleTree
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.util.HashSet;
 import java.util.Set;
 

--- a/bundletree/src/main/java/org/mqnaas/bundletree/impl/ConcurrentBundleGuardData.java
+++ b/bundletree/src/main/java/org/mqnaas/bundletree/impl/ConcurrentBundleGuardData.java
@@ -1,5 +1,27 @@
 package org.mqnaas.bundletree.impl;
 
+/*
+ * #%L
+ * MQNaaS :: BundleTree
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;

--- a/bundletree/src/main/java/org/mqnaas/bundletree/tree/BundleTreeUtils.java
+++ b/bundletree/src/main/java/org/mqnaas/bundletree/tree/BundleTreeUtils.java
@@ -1,5 +1,27 @@
 package org.mqnaas.bundletree.tree;
 
+/*
+ * #%L
+ * MQNaaS :: BundleTree
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;

--- a/bundletree/src/main/java/org/mqnaas/bundletree/tree/Node.java
+++ b/bundletree/src/main/java/org/mqnaas/bundletree/tree/Node.java
@@ -16,6 +16,28 @@
  */
 package org.mqnaas.bundletree.tree;
 
+/*
+ * #%L
+ * MQNaaS :: BundleTree
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;

--- a/bundletree/src/main/java/org/mqnaas/bundletree/tree/Tree.java
+++ b/bundletree/src/main/java/org/mqnaas/bundletree/tree/Tree.java
@@ -16,6 +16,28 @@
  */
 package org.mqnaas.bundletree.tree;
 
+/*
+ * #%L
+ * MQNaaS :: BundleTree
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 /**
  * Represents a tree that can be written to the console.
  * 

--- a/bundletree/src/main/java/org/mqnaas/bundletree/utils/BundleClassPathUtils.java
+++ b/bundletree/src/main/java/org/mqnaas/bundletree/utils/BundleClassPathUtils.java
@@ -1,5 +1,27 @@
 package org.mqnaas.bundletree.utils;
 
+/*
+ * #%L
+ * MQNaaS :: BundleTree
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.lang.reflect.Modifier;
 import java.util.Collections;
 import java.util.HashSet;

--- a/bundletree/src/main/java/org/mqnaas/bundletree/utils/BundleUtils.java
+++ b/bundletree/src/main/java/org/mqnaas/bundletree/utils/BundleUtils.java
@@ -1,5 +1,27 @@
 package org.mqnaas.bundletree.utils;
 
+/*
+ * #%L
+ * MQNaaS :: BundleTree
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;

--- a/bundletree/src/main/java/org/mqnaas/bundletree/utils/ClassFilterFactory.java
+++ b/bundletree/src/main/java/org/mqnaas/bundletree/utils/ClassFilterFactory.java
@@ -1,5 +1,27 @@
 package org.mqnaas.bundletree.utils;
 
+/*
+ * #%L
+ * MQNaaS :: BundleTree
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.lang.reflect.Modifier;
 import java.util.Arrays;
 import java.util.Collection;

--- a/clientprovider-api/src/main/java/org/mqnaas/clientprovider/api/IEndpointSelectionStrategy.java
+++ b/clientprovider-api/src/main/java/org/mqnaas/clientprovider/api/IEndpointSelectionStrategy.java
@@ -1,5 +1,27 @@
 package org.mqnaas.clientprovider.api;
 
+/*
+ * #%L
+ * MQNaaS :: Client Provider API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.util.Collection;
 
 import org.mqnaas.core.api.Endpoint;

--- a/clientprovider-api/src/main/java/org/mqnaas/clientprovider/api/apiclient/IAPIClientProvider.java
+++ b/clientprovider-api/src/main/java/org/mqnaas/clientprovider/api/apiclient/IAPIClientProvider.java
@@ -1,5 +1,27 @@
 package org.mqnaas.clientprovider.api.apiclient;
 
+/*
+ * #%L
+ * MQNaaS :: Client Provider API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.mqnaas.clientprovider.exceptions.EndpointNotFoundException;
 import org.mqnaas.core.api.IResource;
 

--- a/clientprovider-api/src/main/java/org/mqnaas/clientprovider/api/apiclient/IAPIClientProviderFactory.java
+++ b/clientprovider-api/src/main/java/org/mqnaas/clientprovider/api/apiclient/IAPIClientProviderFactory.java
@@ -1,5 +1,27 @@
 package org.mqnaas.clientprovider.api.apiclient;
 
+/*
+ * #%L
+ * MQNaaS :: Client Provider API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.mqnaas.clientprovider.api.IEndpointSelectionStrategy;
 import org.mqnaas.clientprovider.exceptions.ProviderNotFoundException;
 import org.mqnaas.core.api.ICapability;

--- a/clientprovider-api/src/main/java/org/mqnaas/clientprovider/api/apiclient/IInternalAPIClientProvider.java
+++ b/clientprovider-api/src/main/java/org/mqnaas/clientprovider/api/apiclient/IInternalAPIClientProvider.java
@@ -1,5 +1,27 @@
 package org.mqnaas.clientprovider.api.apiclient;
 
+/*
+ * #%L
+ * MQNaaS :: Client Provider API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.mqnaas.clientprovider.exceptions.ClientConfigurationException;
 import org.mqnaas.core.api.Endpoint;
 import org.mqnaas.core.api.credentials.Credentials;

--- a/clientprovider-api/src/main/java/org/mqnaas/clientprovider/api/client/IClientProvider.java
+++ b/clientprovider-api/src/main/java/org/mqnaas/clientprovider/api/client/IClientProvider.java
@@ -1,5 +1,27 @@
 package org.mqnaas.clientprovider.api.client;
 
+/*
+ * #%L
+ * MQNaaS :: Client Provider API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.mqnaas.clientprovider.exceptions.EndpointNotFoundException;
 import org.mqnaas.core.api.IResource;
 

--- a/clientprovider-api/src/main/java/org/mqnaas/clientprovider/api/client/IClientProviderFactory.java
+++ b/clientprovider-api/src/main/java/org/mqnaas/clientprovider/api/client/IClientProviderFactory.java
@@ -1,5 +1,27 @@
 package org.mqnaas.clientprovider.api.client;
 
+/*
+ * #%L
+ * MQNaaS :: Client Provider API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.mqnaas.clientprovider.api.IEndpointSelectionStrategy;
 import org.mqnaas.clientprovider.exceptions.ProviderNotFoundException;
 import org.mqnaas.core.api.ICapability;

--- a/clientprovider-api/src/main/java/org/mqnaas/clientprovider/api/client/IInternalClientProvider.java
+++ b/clientprovider-api/src/main/java/org/mqnaas/clientprovider/api/client/IInternalClientProvider.java
@@ -1,5 +1,27 @@
 package org.mqnaas.clientprovider.api.client;
 
+/*
+ * #%L
+ * MQNaaS :: Client Provider API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.mqnaas.core.api.Endpoint;
 import org.mqnaas.core.api.credentials.Credentials;
 

--- a/clientprovider-api/src/main/java/org/mqnaas/clientprovider/exceptions/ClientConfigurationException.java
+++ b/clientprovider-api/src/main/java/org/mqnaas/clientprovider/exceptions/ClientConfigurationException.java
@@ -1,5 +1,27 @@
 package org.mqnaas.clientprovider.exceptions;
 
+/*
+ * #%L
+ * MQNaaS :: Client Provider API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 /**
  * Exception thrown when it is not possible to configure a client with specified configuration information.
  * 

--- a/clientprovider-api/src/main/java/org/mqnaas/clientprovider/exceptions/EndpointNotFoundException.java
+++ b/clientprovider-api/src/main/java/org/mqnaas/clientprovider/exceptions/EndpointNotFoundException.java
@@ -1,5 +1,27 @@
 package org.mqnaas.clientprovider.exceptions;
 
+/*
+ * #%L
+ * MQNaaS :: Client Provider API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.mqnaas.core.api.Endpoint;
 
 /**

--- a/clientprovider-api/src/main/java/org/mqnaas/clientprovider/exceptions/ProviderNotFoundException.java
+++ b/clientprovider-api/src/main/java/org/mqnaas/clientprovider/exceptions/ProviderNotFoundException.java
@@ -1,5 +1,27 @@
 package org.mqnaas.clientprovider.exceptions;
 
+/*
+ * #%L
+ * MQNaaS :: Client Provider API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 /**
  * Exception thrown when it is not possible to find a valid provider in a provider factory.
  * 

--- a/clientprovider/src/main/java/org/mqnaas/client/application/ApplicationConfiguration.java
+++ b/clientprovider/src/main/java/org/mqnaas/client/application/ApplicationConfiguration.java
@@ -1,5 +1,27 @@
 package org.mqnaas.client.application;
 
+/*
+ * #%L
+ * MQNaaS :: Client Provider
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 public class ApplicationConfiguration {
 
 }

--- a/clientprovider/src/main/java/org/mqnaas/client/application/IApplicationClient.java
+++ b/clientprovider/src/main/java/org/mqnaas/client/application/IApplicationClient.java
@@ -1,5 +1,27 @@
 package org.mqnaas.client.application;
 
+/*
+ * #%L
+ * MQNaaS :: Client Provider
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 

--- a/clientprovider/src/main/java/org/mqnaas/client/cxf/CXFConfiguration.java
+++ b/clientprovider/src/main/java/org/mqnaas/client/cxf/CXFConfiguration.java
@@ -1,5 +1,27 @@
 package org.mqnaas.client.cxf;
 
+/*
+ * #%L
+ * MQNaaS :: Client Provider
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.util.ArrayList;
 import java.util.List;
 

--- a/clientprovider/src/main/java/org/mqnaas/client/cxf/ICXFAPIProvider.java
+++ b/clientprovider/src/main/java/org/mqnaas/client/cxf/ICXFAPIProvider.java
@@ -1,5 +1,27 @@
 package org.mqnaas.client.cxf;
 
+/*
+ * #%L
+ * MQNaaS :: Client Provider
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.mqnaas.clientprovider.api.apiclient.IAPIClientProvider;
 
 /**

--- a/clientprovider/src/main/java/org/mqnaas/client/cxf/InternalCXFClientProvider.java
+++ b/clientprovider/src/main/java/org/mqnaas/client/cxf/InternalCXFClientProvider.java
@@ -1,5 +1,27 @@
 package org.mqnaas.client.cxf;
 
+/*
+ * #%L
+ * MQNaaS :: Client Provider
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;

--- a/clientprovider/src/main/java/org/mqnaas/client/netconf/INetconfClientProvider.java
+++ b/clientprovider/src/main/java/org/mqnaas/client/netconf/INetconfClientProvider.java
@@ -1,5 +1,27 @@
 package org.mqnaas.client.netconf;
 
+/*
+ * #%L
+ * MQNaaS :: Client Provider
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.mqnaas.clientprovider.api.client.IClientProvider;
 
 public interface INetconfClientProvider extends IClientProvider<NetconfClient, NetconfConfiguration> {

--- a/clientprovider/src/main/java/org/mqnaas/client/netconf/InternalNetconfClientProvider.java
+++ b/clientprovider/src/main/java/org/mqnaas/client/netconf/InternalNetconfClientProvider.java
@@ -1,5 +1,27 @@
 package org.mqnaas.client.netconf;
 
+/*
+ * #%L
+ * MQNaaS :: Client Provider
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.mqnaas.clientprovider.api.client.IInternalClientProvider;
 import org.mqnaas.core.api.Endpoint;
 import org.mqnaas.core.api.credentials.Credentials;

--- a/clientprovider/src/main/java/org/mqnaas/client/netconf/NetconfClient.java
+++ b/clientprovider/src/main/java/org/mqnaas/client/netconf/NetconfClient.java
@@ -1,5 +1,27 @@
 package org.mqnaas.client.netconf;
 
+/*
+ * #%L
+ * MQNaaS :: Client Provider
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.mqnaas.core.api.Endpoint;
 import org.mqnaas.core.api.credentials.Credentials;
 import org.slf4j.Logger;

--- a/clientprovider/src/main/java/org/mqnaas/client/netconf/NetconfConfiguration.java
+++ b/clientprovider/src/main/java/org/mqnaas/client/netconf/NetconfConfiguration.java
@@ -1,5 +1,27 @@
 package org.mqnaas.client.netconf;
 
+/*
+ * #%L
+ * MQNaaS :: Client Provider
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 public class NetconfConfiguration {
 
 }

--- a/clientprovider/src/main/java/org/mqnaas/clientprovider/impl/AbstractProviderFactory.java
+++ b/clientprovider/src/main/java/org/mqnaas/clientprovider/impl/AbstractProviderFactory.java
@@ -1,5 +1,27 @@
 package org.mqnaas.clientprovider.impl;
 
+/*
+ * #%L
+ * MQNaaS :: Client Provider
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;

--- a/clientprovider/src/main/java/org/mqnaas/clientprovider/impl/BasicEndpointSelectionStrategy.java
+++ b/clientprovider/src/main/java/org/mqnaas/clientprovider/impl/BasicEndpointSelectionStrategy.java
@@ -1,5 +1,27 @@
 package org.mqnaas.clientprovider.impl;
 
+/*
+ * #%L
+ * MQNaaS :: Client Provider
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.net.URI;
 import java.util.Collection;
 

--- a/clientprovider/src/main/java/org/mqnaas/clientprovider/impl/apiclient/APIProviderAdapter.java
+++ b/clientprovider/src/main/java/org/mqnaas/clientprovider/impl/apiclient/APIProviderAdapter.java
@@ -1,5 +1,27 @@
 package org.mqnaas.clientprovider.impl.apiclient;
 
+/*
+ * #%L
+ * MQNaaS :: Client Provider
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 

--- a/clientprovider/src/main/java/org/mqnaas/clientprovider/impl/apiclient/APIProviderFactory.java
+++ b/clientprovider/src/main/java/org/mqnaas/clientprovider/impl/apiclient/APIProviderFactory.java
@@ -1,5 +1,27 @@
 package org.mqnaas.clientprovider.impl.apiclient;
 
+/*
+ * #%L
+ * MQNaaS :: Client Provider
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.lang.reflect.Proxy;
 import java.lang.reflect.Type;
 import java.util.HashSet;

--- a/clientprovider/src/main/java/org/mqnaas/clientprovider/impl/client/ClientProviderAdapter.java
+++ b/clientprovider/src/main/java/org/mqnaas/clientprovider/impl/client/ClientProviderAdapter.java
@@ -1,5 +1,27 @@
 package org.mqnaas.clientprovider.impl.client;
 
+/*
+ * #%L
+ * MQNaaS :: Client Provider
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 

--- a/clientprovider/src/main/java/org/mqnaas/clientprovider/impl/client/ClientProviderFactory.java
+++ b/clientprovider/src/main/java/org/mqnaas/clientprovider/impl/client/ClientProviderFactory.java
@@ -1,5 +1,27 @@
 package org.mqnaas.clientprovider.impl.client;
 
+/*
+ * #%L
+ * MQNaaS :: Client Provider
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.lang.reflect.Proxy;
 import java.lang.reflect.Type;
 import java.util.HashSet;

--- a/clientprovider/src/main/java/test/ClientApplication.java
+++ b/clientprovider/src/main/java/test/ClientApplication.java
@@ -1,5 +1,27 @@
 package test;
 
+/*
+ * #%L
+ * MQNaaS :: Client Provider
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Arrays;

--- a/clientprovider/src/test/java/org/mqnaas/clientprovider/impl/ProviderFactoryTests.java
+++ b/clientprovider/src/test/java/org/mqnaas/clientprovider/impl/ProviderFactoryTests.java
@@ -1,5 +1,27 @@
 package org.mqnaas.clientprovider.impl;
 
+/*
+ * #%L
+ * MQNaaS :: Client Provider
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.lang.reflect.Type;
 import java.util.HashSet;
 import java.util.Set;

--- a/clientprovider/src/test/java/org/mqnaas/clientprovider/impl/apiclient/APIProviderFactoryTest.java
+++ b/clientprovider/src/test/java/org/mqnaas/clientprovider/impl/apiclient/APIProviderFactoryTest.java
@@ -1,5 +1,27 @@
 package org.mqnaas.clientprovider.impl.apiclient;
 
+/*
+ * #%L
+ * MQNaaS :: Client Provider
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.util.Collection;
 
 import org.junit.Assert;

--- a/clientprovider/src/test/java/org/mqnaas/clientprovider/impl/client/ClientProviderFactoryTest.java
+++ b/clientprovider/src/test/java/org/mqnaas/clientprovider/impl/client/ClientProviderFactoryTest.java
@@ -1,5 +1,27 @@
 package org.mqnaas.clientprovider.impl.client;
 
+/*
+ * #%L
+ * MQNaaS :: Client Provider
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.net.URI;
 import java.net.URISyntaxException;
 

--- a/core.api/src/main/java/org/i2cat/utils/StringBuilderUtils.java
+++ b/core.api/src/main/java/org/i2cat/utils/StringBuilderUtils.java
@@ -1,5 +1,27 @@
 package org.i2cat.utils;
 
+/*
+ * #%L
+ * MQNaaS :: Core.API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.util.Arrays;
 import java.util.Collection;
 

--- a/core.api/src/main/java/org/mqnaas/core/api/Endpoint.java
+++ b/core.api/src/main/java/org/mqnaas/core/api/Endpoint.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.api;
 
+/*
+ * #%L
+ * MQNaaS :: Core.API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.net.URI;
 
 public class Endpoint {

--- a/core.api/src/main/java/org/mqnaas/core/api/ExecutionContext.java
+++ b/core.api/src/main/java/org/mqnaas/core/api/ExecutionContext.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.api;
 
+/*
+ * #%L
+ * MQNaaS :: Core.API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 /**
  * The <code>ExecutionContext</code> is the context which stores all information necessary to represent the state of an execution, e.g. locks,
  * participating resources, ...

--- a/core.api/src/main/java/org/mqnaas/core/api/IApplication.java
+++ b/core.api/src/main/java/org/mqnaas/core/api/IApplication.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.api;
 
+/*
+ * #%L
+ * MQNaaS :: Core.API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.mqnaas.core.api.annotations.DependingOn;
 import org.mqnaas.core.api.exceptions.ApplicationActivationException;
 

--- a/core.api/src/main/java/org/mqnaas/core/api/IAttributeStore.java
+++ b/core.api/src/main/java/org/mqnaas/core/api/IAttributeStore.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.api;
 
+/*
+ * #%L
+ * MQNaaS :: Core.API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 /**
  * A simple store for String values which can be bound to any {@link IResource} if necessary.
  * 

--- a/core.api/src/main/java/org/mqnaas/core/api/IBindingDecider.java
+++ b/core.api/src/main/java/org/mqnaas/core/api/IBindingDecider.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.api;
 
+/*
+ * #%L
+ * MQNaaS :: Core.API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 /**
  * <p>
  * <code>IBindingDecider</code> provides the logic to decide when {@link ICapability}'s should be bound to {@link IResource}'s.

--- a/core.api/src/main/java/org/mqnaas/core/api/ICapability.java
+++ b/core.api/src/main/java/org/mqnaas/core/api/ICapability.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.api;
 
+/*
+ * #%L
+ * MQNaaS :: Core.API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.mqnaas.core.api.annotations.DependingOn;
 
 /**

--- a/core.api/src/main/java/org/mqnaas/core/api/ICoreModelCapability.java
+++ b/core.api/src/main/java/org/mqnaas/core/api/ICoreModelCapability.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.api;
 
+/*
+ * #%L
+ * MQNaaS :: Core.API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 
 /**
  * This {@link ICapability} groups all the operations that can be requested to core implementation.

--- a/core.api/src/main/java/org/mqnaas/core/api/ICoreProvider.java
+++ b/core.api/src/main/java/org/mqnaas/core/api/ICoreProvider.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.api;
 
+/*
+ * #%L
+ * MQNaaS :: Core.API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.mqnaas.core.api.Specification.Type;
 
 /**

--- a/core.api/src/main/java/org/mqnaas/core/api/IExecutionService.java
+++ b/core.api/src/main/java/org/mqnaas/core/api/IExecutionService.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.api;
 
+/*
+ * #%L
+ * MQNaaS :: Core.API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.lang.reflect.InvocationTargetException;
 
 /**

--- a/core.api/src/main/java/org/mqnaas/core/api/IIdentifiable.java
+++ b/core.api/src/main/java/org/mqnaas/core/api/IIdentifiable.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.api;
 
+/*
+ * #%L
+ * MQNaaS :: Core.API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 /**
  * <p>
  * Marker interfaces that defines that an object contains a unique Id.

--- a/core.api/src/main/java/org/mqnaas/core/api/ILockingBehaviour.java
+++ b/core.api/src/main/java/org/mqnaas/core/api/ILockingBehaviour.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.api;
 
+/*
+ * #%L
+ * MQNaaS :: Core.API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 /**
  * <p>
  * <code>ILockingBehaviour</code> defines the locking behavior of a {@link IRootResource} in MQNaaS.

--- a/core.api/src/main/java/org/mqnaas/core/api/IObservationFilter.java
+++ b/core.api/src/main/java/org/mqnaas/core/api/IObservationFilter.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.api;
 
+/*
+ * #%L
+ * MQNaaS :: Core.API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 /**
  * <p>
  * An <code>IObservationFilter</code> is responsible for deciding whether a given {@link IService} should be monitored.

--- a/core.api/src/main/java/org/mqnaas/core/api/IObservationService.java
+++ b/core.api/src/main/java/org/mqnaas/core/api/IObservationService.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.api;
 
+/*
+ * #%L
+ * MQNaaS :: Core.API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 /**
  * 
  * <p>

--- a/core.api/src/main/java/org/mqnaas/core/api/IResource.java
+++ b/core.api/src/main/java/org/mqnaas/core/api/IResource.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.api;
 
+/*
+ * #%L
+ * MQNaaS :: Core.API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 /**
  * This is just a marker interface to identify an MQNaaS resource.
  */

--- a/core.api/src/main/java/org/mqnaas/core/api/IResourceManagementListener.java
+++ b/core.api/src/main/java/org/mqnaas/core/api/IResourceManagementListener.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.api;
 
+/*
+ * #%L
+ * MQNaaS :: Core.API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.mqnaas.core.api.exceptions.ApplicationNotFoundException;
 import org.mqnaas.core.api.exceptions.CapabilityNotFoundException;
 

--- a/core.api/src/main/java/org/mqnaas/core/api/IResourceTreeCapability.java
+++ b/core.api/src/main/java/org/mqnaas/core/api/IResourceTreeCapability.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.api;
 
+/*
+ * #%L
+ * MQNaaS :: Core.API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 public interface IResourceTreeCapability extends ICapability {
 
 	IApplication getInstance(Class<? extends IApplication> applicationClazz);

--- a/core.api/src/main/java/org/mqnaas/core/api/IRootResource.java
+++ b/core.api/src/main/java/org/mqnaas/core/api/IRootResource.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.api;
 
+/*
+ * #%L
+ * MQNaaS :: Core.API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 /**
  * <p>
  * <code>IRootResource</code> is the representation of a physical device in MQNaaS.

--- a/core.api/src/main/java/org/mqnaas/core/api/IRootResourceAdministration.java
+++ b/core.api/src/main/java/org/mqnaas/core/api/IRootResourceAdministration.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.api;
 
+/*
+ * #%L
+ * MQNaaS :: Core.API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.mqnaas.core.api.annotations.AddsResource;
 import org.mqnaas.core.api.annotations.RemovesResource;
 import org.mqnaas.core.api.exceptions.ResourceNotFoundException;

--- a/core.api/src/main/java/org/mqnaas/core/api/IRootResourceProvider.java
+++ b/core.api/src/main/java/org/mqnaas/core/api/IRootResourceProvider.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.api;
 
+/*
+ * #%L
+ * MQNaaS :: Core.API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.util.Collection;
 import java.util.List;
 

--- a/core.api/src/main/java/org/mqnaas/core/api/IService.java
+++ b/core.api/src/main/java/org/mqnaas/core/api/IService.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.api;
 
+/*
+ * #%L
+ * MQNaaS :: Core.API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 /**
  * The <code>IService</code>
  */

--- a/core.api/src/main/java/org/mqnaas/core/api/IServiceMetaData.java
+++ b/core.api/src/main/java/org/mqnaas/core/api/IServiceMetaData.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.api;
 
+/*
+ * #%L
+ * MQNaaS :: Core.API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 

--- a/core.api/src/main/java/org/mqnaas/core/api/IServiceProvider.java
+++ b/core.api/src/main/java/org/mqnaas/core/api/IServiceProvider.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.api;
 
+/*
+ * #%L
+ * MQNaaS :: Core.API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.mqnaas.core.api.exceptions.CapabilityNotFoundException;
 import org.mqnaas.core.api.exceptions.ServiceNotFoundException;
 

--- a/core.api/src/main/java/org/mqnaas/core/api/ITransactionBehavior.java
+++ b/core.api/src/main/java/org/mqnaas/core/api/ITransactionBehavior.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.api;
 
+/*
+ * #%L
+ * MQNaaS :: Core.API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 /**
  * <code>ITransactionBehavior</code> defines the way in which a resource participates in a transaction.
  */

--- a/core.api/src/main/java/org/mqnaas/core/api/RootResourceDescriptor.java
+++ b/core.api/src/main/java/org/mqnaas/core/api/RootResourceDescriptor.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.api;
 
+/*
+ * #%L
+ * MQNaaS :: Core.API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;

--- a/core.api/src/main/java/org/mqnaas/core/api/Specification.java
+++ b/core.api/src/main/java/org/mqnaas/core/api/Specification.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.api;
 
+/*
+ * #%L
+ * MQNaaS :: Core.API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;

--- a/core.api/src/main/java/org/mqnaas/core/api/annotations/AddsResource.java
+++ b/core.api/src/main/java/org/mqnaas/core/api/annotations/AddsResource.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.api.annotations;
 
+/*
+ * #%L
+ * MQNaaS :: Core.API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;

--- a/core.api/src/main/java/org/mqnaas/core/api/annotations/DependingOn.java
+++ b/core.api/src/main/java/org/mqnaas/core/api/annotations/DependingOn.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.api.annotations;
 
+/*
+ * #%L
+ * MQNaaS :: Core.API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;

--- a/core.api/src/main/java/org/mqnaas/core/api/annotations/ListsResources.java
+++ b/core.api/src/main/java/org/mqnaas/core/api/annotations/ListsResources.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.api.annotations;
 
+/*
+ * #%L
+ * MQNaaS :: Core.API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;

--- a/core.api/src/main/java/org/mqnaas/core/api/annotations/RemovesResource.java
+++ b/core.api/src/main/java/org/mqnaas/core/api/annotations/RemovesResource.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.api.annotations;
 
+/*
+ * #%L
+ * MQNaaS :: Core.API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;

--- a/core.api/src/main/java/org/mqnaas/core/api/annotations/Resource.java
+++ b/core.api/src/main/java/org/mqnaas/core/api/annotations/Resource.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.api.annotations;
 
+/*
+ * #%L
+ * MQNaaS :: Core.API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;

--- a/core.api/src/main/java/org/mqnaas/core/api/credentials/Credentials.java
+++ b/core.api/src/main/java/org/mqnaas/core/api/credentials/Credentials.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.api.credentials;
 
+/*
+ * #%L
+ * MQNaaS :: Core.API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlSeeAlso;
 

--- a/core.api/src/main/java/org/mqnaas/core/api/credentials/TrustoreKeystoreCredentials.java
+++ b/core.api/src/main/java/org/mqnaas/core/api/credentials/TrustoreKeystoreCredentials.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.api.credentials;
 
+/*
+ * #%L
+ * MQNaaS :: Core.API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.net.URI;
 
 import javax.xml.bind.annotation.XmlAccessType;

--- a/core.api/src/main/java/org/mqnaas/core/api/credentials/UsernamePasswordCredentials.java
+++ b/core.api/src/main/java/org/mqnaas/core/api/credentials/UsernamePasswordCredentials.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.api.credentials;
 
+/*
+ * #%L
+ * MQNaaS :: Core.API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;

--- a/core.api/src/main/java/org/mqnaas/core/api/exceptions/ApplicationActivationException.java
+++ b/core.api/src/main/java/org/mqnaas/core/api/exceptions/ApplicationActivationException.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.api.exceptions;
 
+/*
+ * #%L
+ * MQNaaS :: Core.API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.mqnaas.core.api.IApplication;
 
 /**

--- a/core.api/src/main/java/org/mqnaas/core/api/exceptions/ApplicationNotFoundException.java
+++ b/core.api/src/main/java/org/mqnaas/core/api/exceptions/ApplicationNotFoundException.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.api.exceptions;
 
+/*
+ * #%L
+ * MQNaaS :: Core.API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.mqnaas.core.api.IApplication;
 
 /**

--- a/core.api/src/main/java/org/mqnaas/core/api/exceptions/CapabilityNotFoundException.java
+++ b/core.api/src/main/java/org/mqnaas/core/api/exceptions/CapabilityNotFoundException.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.api.exceptions;
 
+/*
+ * #%L
+ * MQNaaS :: Core.API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.mqnaas.core.api.ICapability;
 
 /**

--- a/core.api/src/main/java/org/mqnaas/core/api/exceptions/InternalModelInitializationException.java
+++ b/core.api/src/main/java/org/mqnaas/core/api/exceptions/InternalModelInitializationException.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.api.exceptions;
 
+/*
+ * #%L
+ * MQNaaS :: Core.API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.mqnaas.core.api.IApplication;
 
 /**

--- a/core.api/src/main/java/org/mqnaas/core/api/exceptions/ResourceNotFoundException.java
+++ b/core.api/src/main/java/org/mqnaas/core/api/exceptions/ResourceNotFoundException.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.api.exceptions;
 
+/*
+ * #%L
+ * MQNaaS :: Core.API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 public class ResourceNotFoundException extends Exception {
 
 	private static final long	serialVersionUID	= -2681386586234918505L;

--- a/core.api/src/main/java/org/mqnaas/core/api/exceptions/ServiceExecutionSchedulerException.java
+++ b/core.api/src/main/java/org/mqnaas/core/api/exceptions/ServiceExecutionSchedulerException.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.api.exceptions;
 
+/*
+ * #%L
+ * MQNaaS :: Core.API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 /**
  * 
  * @author Adrián Roselló Rey (i2CAT)

--- a/core.api/src/main/java/org/mqnaas/core/api/exceptions/ServiceNotFoundException.java
+++ b/core.api/src/main/java/org/mqnaas/core/api/exceptions/ServiceNotFoundException.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.api.exceptions;
 
+/*
+ * #%L
+ * MQNaaS :: Core.API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 public class ServiceNotFoundException extends Exception {
 
 	private static final long	serialVersionUID	= -6226616898967244097L;

--- a/core.api/src/main/java/org/mqnaas/core/api/scheduling/IServiceExecutionScheduler.java
+++ b/core.api/src/main/java/org/mqnaas/core/api/scheduling/IServiceExecutionScheduler.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.api.scheduling;
 
+/*
+ * #%L
+ * MQNaaS :: Core.API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.util.Set;
 
 import org.mqnaas.core.api.ICapability;

--- a/core.api/src/main/java/org/mqnaas/core/api/scheduling/ServiceExecution.java
+++ b/core.api/src/main/java/org/mqnaas/core/api/scheduling/ServiceExecution.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.api.scheduling;
 
+/*
+ * #%L
+ * MQNaaS :: Core.API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.util.Arrays;
 
 import org.mqnaas.core.api.IService;

--- a/core.api/src/main/java/org/mqnaas/core/api/scheduling/Trigger.java
+++ b/core.api/src/main/java/org/mqnaas/core/api/scheduling/Trigger.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.api.scheduling;
 
+/*
+ * #%L
+ * MQNaaS :: Core.API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.util.Date;
 
 import org.mqnaas.core.api.IService;

--- a/core.api/src/main/java/org/mqnaas/core/api/slicing/Cube.java
+++ b/core.api/src/main/java/org/mqnaas/core/api/slicing/Cube.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.api.slicing;
 
+/*
+ * #%L
+ * MQNaaS :: Core.API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.io.Serializable;
 import java.util.Arrays;
 

--- a/core.api/src/main/java/org/mqnaas/core/api/slicing/CubesList.java
+++ b/core.api/src/main/java/org/mqnaas/core/api/slicing/CubesList.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.api.slicing;
 
+/*
+ * #%L
+ * MQNaaS :: Core.API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.util.ArrayList;
 import java.util.Collection;
 

--- a/core.api/src/main/java/org/mqnaas/core/api/slicing/ISliceAdministration.java
+++ b/core.api/src/main/java/org/mqnaas/core/api/slicing/ISliceAdministration.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.api.slicing;
 
+/*
+ * #%L
+ * MQNaaS :: Core.API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.mqnaas.core.api.ICapability;
 import org.mqnaas.core.api.IResource;
 

--- a/core.api/src/main/java/org/mqnaas/core/api/slicing/ISliceProvider.java
+++ b/core.api/src/main/java/org/mqnaas/core/api/slicing/ISliceProvider.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.api.slicing;
 
+/*
+ * #%L
+ * MQNaaS :: Core.API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.mqnaas.core.api.ICapability;
 import org.mqnaas.core.api.IResource;
 

--- a/core.api/src/main/java/org/mqnaas/core/api/slicing/ISlicingCapability.java
+++ b/core.api/src/main/java/org/mqnaas/core/api/slicing/ISlicingCapability.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.api.slicing;
 
+/*
+ * #%L
+ * MQNaaS :: Core.API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.util.Collection;
 
 import org.mqnaas.core.api.ICapability;

--- a/core.api/src/main/java/org/mqnaas/core/api/slicing/IUnitAdministration.java
+++ b/core.api/src/main/java/org/mqnaas/core/api/slicing/IUnitAdministration.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.api.slicing;
 
+/*
+ * #%L
+ * MQNaaS :: Core.API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.mqnaas.core.api.ICapability;
 
 /**

--- a/core.api/src/main/java/org/mqnaas/core/api/slicing/IUnitManagement.java
+++ b/core.api/src/main/java/org/mqnaas/core/api/slicing/IUnitManagement.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.api.slicing;
 
+/*
+ * #%L
+ * MQNaaS :: Core.API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.util.List;
 
 import org.mqnaas.core.api.ICapability;

--- a/core.api/src/main/java/org/mqnaas/core/api/slicing/Range.java
+++ b/core.api/src/main/java/org/mqnaas/core/api/slicing/Range.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.api.slicing;
 
+/*
+ * #%L
+ * MQNaaS :: Core.API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.io.Serializable;
 
 import javax.xml.bind.annotation.XmlAccessType;

--- a/core.api/src/main/java/org/mqnaas/core/api/slicing/SlicingException.java
+++ b/core.api/src/main/java/org/mqnaas/core/api/slicing/SlicingException.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.api.slicing;
 
+/*
+ * #%L
+ * MQNaaS :: Core.API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 /**
  * 
  * @author Adrián Roselló Rey (i2CAT)

--- a/core.api/src/test/java/org/mqnaas/core/api/RootResourceDescriptorTest.java
+++ b/core.api/src/test/java/org/mqnaas/core/api/RootResourceDescriptorTest.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.api;
 
+/*
+ * #%L
+ * MQNaaS :: Core.API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Arrays;

--- a/core.api/src/test/java/org/mqnaas/core/api/serialization/RootResourceDescriptorSerializationTest.java
+++ b/core.api/src/test/java/org/mqnaas/core/api/serialization/RootResourceDescriptorSerializationTest.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.api.serialization;
 
+/*
+ * #%L
+ * MQNaaS :: Core.API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;

--- a/core.api/src/test/java/org/mqnaas/core/api/serialization/SliceCubeSerializationTest.java
+++ b/core.api/src/test/java/org/mqnaas/core/api/serialization/SliceCubeSerializationTest.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.api.serialization;
 
+/*
+ * #%L
+ * MQNaaS :: Core.API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.io.IOException;
 
 import javax.xml.bind.JAXBException;

--- a/core.api/src/test/java/org/mqnaas/core/api/serialization/SpecificationSerializationTest.java
+++ b/core.api/src/test/java/org/mqnaas/core/api/serialization/SpecificationSerializationTest.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.api.serialization;
 
+/*
+ * #%L
+ * MQNaaS :: Core.API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.io.IOException;
 
 import javax.xml.bind.JAXBException;

--- a/core.api/src/test/java/org/mqnaas/core/api/slicing/RangeTest.java
+++ b/core.api/src/test/java/org/mqnaas/core/api/slicing/RangeTest.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.api.slicing;
 
+/*
+ * #%L
+ * MQNaaS :: Core.API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.junit.Assert;
 import org.junit.Test;
 

--- a/core/src/main/java/org/mqnaas/core/impl/ApplicationInstance.java
+++ b/core/src/main/java/org/mqnaas/core/impl/ApplicationInstance.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Collection;

--- a/core/src/main/java/org/mqnaas/core/impl/ApplicationProxyHolder.java
+++ b/core/src/main/java/org/mqnaas/core/impl/ApplicationProxyHolder.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;

--- a/core/src/main/java/org/mqnaas/core/impl/AttributeStore.java
+++ b/core/src/main/java/org/mqnaas/core/impl/AttributeStore.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 

--- a/core/src/main/java/org/mqnaas/core/impl/Attributes.java
+++ b/core/src/main/java/org/mqnaas/core/impl/Attributes.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.mqnaas.core.api.IAttributeStore;
 import org.mqnaas.core.api.ICapability;
 import org.mqnaas.core.api.IResource;

--- a/core/src/main/java/org/mqnaas/core/impl/BinderDecider.java
+++ b/core/src/main/java/org/mqnaas/core/impl/BinderDecider.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.lang.reflect.Method;
 import java.util.List;
 

--- a/core/src/main/java/org/mqnaas/core/impl/BindingManagement.java
+++ b/core/src/main/java/org/mqnaas/core/impl/BindingManagement.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/core/src/main/java/org/mqnaas/core/impl/CapabilityInstance.java
+++ b/core/src/main/java/org/mqnaas/core/impl/CapabilityInstance.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Collection;

--- a/core/src/main/java/org/mqnaas/core/impl/CoreProvider.java
+++ b/core/src/main/java/org/mqnaas/core/impl/CoreProvider.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.mqnaas.core.api.ICoreProvider;
 import org.mqnaas.core.api.IRootResource;
 import org.mqnaas.core.api.Specification.Type;

--- a/core/src/main/java/org/mqnaas/core/impl/DefaultLockingBehaviour.java
+++ b/core/src/main/java/org/mqnaas/core/impl/DefaultLockingBehaviour.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.util.HashMap;
 import java.util.Map;
 

--- a/core/src/main/java/org/mqnaas/core/impl/ExecutionService.java
+++ b/core/src/main/java/org/mqnaas/core/impl/ExecutionService.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.lang.reflect.InvocationTargetException;
 import java.util.HashMap;
 import java.util.Map;

--- a/core/src/main/java/org/mqnaas/core/impl/IBindingManagement.java
+++ b/core/src/main/java/org/mqnaas/core/impl/IBindingManagement.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.mqnaas.core.api.IApplication;
 import org.mqnaas.core.api.ICapability;
 import org.mqnaas.core.impl.exceptions.ApplicationInstanceNotFoundException;

--- a/core/src/main/java/org/mqnaas/core/impl/IBindingManagementEventListener.java
+++ b/core/src/main/java/org/mqnaas/core/impl/IBindingManagementEventListener.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.mqnaas.core.impl.resourcetree.ApplicationNode;
 import org.mqnaas.core.impl.resourcetree.CapabilityNode;
 import org.mqnaas.core.impl.resourcetree.ResourceNode;

--- a/core/src/main/java/org/mqnaas/core/impl/IInternalResourceManagementListener.java
+++ b/core/src/main/java/org/mqnaas/core/impl/IInternalResourceManagementListener.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.mqnaas.core.api.ICapability;
 import org.mqnaas.core.api.IResource;
 

--- a/core/src/main/java/org/mqnaas/core/impl/IInternalService.java
+++ b/core/src/main/java/org/mqnaas/core/impl/IInternalService.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.lang.reflect.InvocationTargetException;
 
 import org.mqnaas.core.api.IResource;

--- a/core/src/main/java/org/mqnaas/core/impl/RootResource.java
+++ b/core/src/main/java/org/mqnaas/core/impl/RootResource.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.xml.bind.annotation.XmlRootElement;

--- a/core/src/main/java/org/mqnaas/core/impl/RootResourceManagement.java
+++ b/core/src/main/java/org/mqnaas/core/impl/RootResourceManagement.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;

--- a/core/src/main/java/org/mqnaas/core/impl/Service.java
+++ b/core/src/main/java/org/mqnaas/core/impl/Service.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 

--- a/core/src/main/java/org/mqnaas/core/impl/ServiceMetaData.java
+++ b/core/src/main/java/org/mqnaas/core/impl/ServiceMetaData.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 

--- a/core/src/main/java/org/mqnaas/core/impl/UnawareTransactionBehaviour.java
+++ b/core/src/main/java/org/mqnaas/core/impl/UnawareTransactionBehaviour.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.mqnaas.core.api.ITransactionBehavior;
 
 public class UnawareTransactionBehaviour implements ITransactionBehavior {

--- a/core/src/main/java/org/mqnaas/core/impl/dependencies/ApplicationInstanceLifeCycleState.java
+++ b/core/src/main/java/org/mqnaas/core/impl/dependencies/ApplicationInstanceLifeCycleState.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl.dependencies;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 /**
  * 
  * @author Isart Canyameres Gimenez (i2cat)

--- a/core/src/main/java/org/mqnaas/core/impl/dependencies/ApplicationInstanceLifeCycleStateListener.java
+++ b/core/src/main/java/org/mqnaas/core/impl/dependencies/ApplicationInstanceLifeCycleStateListener.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl.dependencies;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.mqnaas.core.impl.ApplicationInstance;
 
 /**

--- a/core/src/main/java/org/mqnaas/core/impl/dependencies/DependencyChainUtils.java
+++ b/core/src/main/java/org/mqnaas/core/impl/dependencies/DependencyChainUtils.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl.dependencies;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.util.ArrayList;
 import java.util.Collection;
 

--- a/core/src/main/java/org/mqnaas/core/impl/dependencies/DependencyManagement.java
+++ b/core/src/main/java/org/mqnaas/core/impl/dependencies/DependencyManagement.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl.dependencies;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;

--- a/core/src/main/java/org/mqnaas/core/impl/exceptions/ApplicationInstanceNotFoundException.java
+++ b/core/src/main/java/org/mqnaas/core/impl/exceptions/ApplicationInstanceNotFoundException.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl.exceptions;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.mqnaas.core.impl.ApplicationInstance;
 
 /**

--- a/core/src/main/java/org/mqnaas/core/impl/exceptions/CapabilityInstanceNotFoundException.java
+++ b/core/src/main/java/org/mqnaas/core/impl/exceptions/CapabilityInstanceNotFoundException.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl.exceptions;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.mqnaas.core.impl.CapabilityInstance;
 
 /**

--- a/core/src/main/java/org/mqnaas/core/impl/notificationfilter/ResourceMonitoringFilter.java
+++ b/core/src/main/java/org/mqnaas/core/impl/notificationfilter/ResourceMonitoringFilter.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl.notificationfilter;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.List;

--- a/core/src/main/java/org/mqnaas/core/impl/notificationfilter/ServiceFilter.java
+++ b/core/src/main/java/org/mqnaas/core/impl/notificationfilter/ServiceFilter.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl.notificationfilter;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.mqnaas.core.api.IObservationFilter;
 import org.mqnaas.core.api.IService;
 

--- a/core/src/main/java/org/mqnaas/core/impl/notificationfilter/ServiceFilterWithParams.java
+++ b/core/src/main/java/org/mqnaas/core/impl/notificationfilter/ServiceFilterWithParams.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl.notificationfilter;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.util.Arrays;
 
 import org.mqnaas.core.api.IService;

--- a/core/src/main/java/org/mqnaas/core/impl/resourcetree/ApplicationNode.java
+++ b/core/src/main/java/org/mqnaas/core/impl/resourcetree/ApplicationNode.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl.resourcetree;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 

--- a/core/src/main/java/org/mqnaas/core/impl/resourcetree/CapabilityNode.java
+++ b/core/src/main/java/org/mqnaas/core/impl/resourcetree/CapabilityNode.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl.resourcetree;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.mqnaas.core.impl.ApplicationInstance;
 import org.mqnaas.core.impl.CapabilityInstance;
 

--- a/core/src/main/java/org/mqnaas/core/impl/resourcetree/ResourceCapabilityTree.java
+++ b/core/src/main/java/org/mqnaas/core/impl/resourcetree/ResourceCapabilityTree.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl.resourcetree;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 /**
  * 
  * @author Isart Canyameres Gimenez (i2cat)

--- a/core/src/main/java/org/mqnaas/core/impl/resourcetree/ResourceCapabilityTreeController.java
+++ b/core/src/main/java/org/mqnaas/core/impl/resourcetree/ResourceCapabilityTreeController.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl.resourcetree;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.util.LinkedList;
 import java.util.List;
 

--- a/core/src/main/java/org/mqnaas/core/impl/resourcetree/ResourceNode.java
+++ b/core/src/main/java/org/mqnaas/core/impl/resourcetree/ResourceNode.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl.resourcetree;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 

--- a/core/src/main/java/org/mqnaas/core/impl/scheduling/BasicTrigger.java
+++ b/core/src/main/java/org/mqnaas/core/impl/scheduling/BasicTrigger.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl.scheduling;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.util.Date;
 
 import org.mqnaas.core.api.scheduling.Trigger;

--- a/core/src/main/java/org/mqnaas/core/impl/scheduling/IServiceExecutionCallback.java
+++ b/core/src/main/java/org/mqnaas/core/impl/scheduling/IServiceExecutionCallback.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl.scheduling;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.mqnaas.core.api.scheduling.ServiceExecution;
 
 /**

--- a/core/src/main/java/org/mqnaas/core/impl/scheduling/JobDetailBuilder.java
+++ b/core/src/main/java/org/mqnaas/core/impl/scheduling/JobDetailBuilder.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl.scheduling;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.util.UUID;
 
 import org.mqnaas.core.api.IExecutionService;

--- a/core/src/main/java/org/mqnaas/core/impl/scheduling/ScheduledJob.java
+++ b/core/src/main/java/org/mqnaas/core/impl/scheduling/ScheduledJob.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl.scheduling;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.lang.reflect.InvocationTargetException;
 
 import org.mqnaas.core.api.IExecutionService;

--- a/core/src/main/java/org/mqnaas/core/impl/scheduling/ServiceExecutionScheduler.java
+++ b/core/src/main/java/org/mqnaas/core/impl/scheduling/ServiceExecutionScheduler.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl.scheduling;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;

--- a/core/src/main/java/org/mqnaas/core/impl/scheduling/TriggerBuilder.java
+++ b/core/src/main/java/org/mqnaas/core/impl/scheduling/TriggerBuilder.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl.scheduling;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.util.UUID;
 
 import org.apache.commons.lang3.StringUtils;

--- a/core/src/main/java/org/mqnaas/core/impl/scheduling/TriggerFactory.java
+++ b/core/src/main/java/org/mqnaas/core/impl/scheduling/TriggerFactory.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl.scheduling;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.util.Date;
 
 import org.mqnaas.core.api.scheduling.Trigger;

--- a/core/src/main/java/org/mqnaas/core/impl/slicing/AbstractCXFSlicingCapability.java
+++ b/core/src/main/java/org/mqnaas/core/impl/slicing/AbstractCXFSlicingCapability.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl.slicing;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;

--- a/core/src/main/java/org/mqnaas/core/impl/slicing/Slice.java
+++ b/core/src/main/java/org/mqnaas/core/impl/slicing/Slice.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl.slicing;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;

--- a/core/src/main/java/org/mqnaas/core/impl/slicing/SliceAdministration.java
+++ b/core/src/main/java/org/mqnaas/core/impl/slicing/SliceAdministration.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl.slicing;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/core/src/main/java/org/mqnaas/core/impl/slicing/SliceProvider.java
+++ b/core/src/main/java/org/mqnaas/core/impl/slicing/SliceProvider.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl.slicing;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.lang.reflect.Method;
 
 import org.mqnaas.core.api.IResource;

--- a/core/src/main/java/org/mqnaas/core/impl/slicing/SliceProvidingResource.java
+++ b/core/src/main/java/org/mqnaas/core/impl/slicing/SliceProvidingResource.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl.slicing;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.mqnaas.core.api.ICapability;
 import org.mqnaas.core.api.IResource;
 import org.mqnaas.core.api.IServiceProvider;

--- a/core/src/main/java/org/mqnaas/core/impl/slicing/SliceResource.java
+++ b/core/src/main/java/org/mqnaas/core/impl/slicing/SliceResource.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl.slicing;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.mqnaas.core.api.IResource;

--- a/core/src/main/java/org/mqnaas/core/impl/slicing/SliceableResource.java
+++ b/core/src/main/java/org/mqnaas/core/impl/slicing/SliceableResource.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl.slicing;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.util.Collection;
 
 import org.mqnaas.core.api.ICapability;

--- a/core/src/main/java/org/mqnaas/core/impl/slicing/Unit.java
+++ b/core/src/main/java/org/mqnaas/core/impl/slicing/Unit.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl.slicing;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.mqnaas.core.api.IResource;
 import org.mqnaas.core.api.IServiceProvider;
 import org.mqnaas.core.api.exceptions.CapabilityNotFoundException;

--- a/core/src/main/java/org/mqnaas/core/impl/slicing/UnitAdministration.java
+++ b/core/src/main/java/org/mqnaas/core/impl/slicing/UnitAdministration.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl.slicing;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.mqnaas.core.api.IResource;
 import org.mqnaas.core.api.annotations.Resource;
 import org.mqnaas.core.api.exceptions.ApplicationActivationException;

--- a/core/src/main/java/org/mqnaas/core/impl/slicing/UnitManagment.java
+++ b/core/src/main/java/org/mqnaas/core/impl/slicing/UnitManagment.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl.slicing;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;

--- a/core/src/main/java/org/mqnaas/core/impl/slicing/UnitResource.java
+++ b/core/src/main/java/org/mqnaas/core/impl/slicing/UnitResource.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl.slicing;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.io.Serializable;
 import java.util.concurrent.atomic.AtomicInteger;
 

--- a/core/src/main/java/org/mqnaas/core/impl/utils/ClassMap.java
+++ b/core/src/main/java/org/mqnaas/core/impl/utils/ClassMap.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl.utils;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;

--- a/core/src/main/java/org/mqnaas/core/impl/utils/ReflectionUtils.java
+++ b/core/src/main/java/org/mqnaas/core/impl/utils/ReflectionUtils.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl.utils;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.util.ArrayList;

--- a/core/src/test/java/org/mqnaas/core/impl/BindingManagementReactsToResourcesTest.java
+++ b/core/src/test/java/org/mqnaas/core/impl/BindingManagementReactsToResourcesTest.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;

--- a/core/src/test/java/org/mqnaas/core/impl/BindingManagementTest.java
+++ b/core/src/test/java/org/mqnaas/core/impl/BindingManagementTest.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.util.ArrayList;
 import java.util.List;
 

--- a/core/src/test/java/org/mqnaas/core/impl/ISample2Capability.java
+++ b/core/src/test/java/org/mqnaas/core/impl/ISample2Capability.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.mqnaas.core.api.ICapability;
 
 /**

--- a/core/src/test/java/org/mqnaas/core/impl/ISampleCapability.java
+++ b/core/src/test/java/org/mqnaas/core/impl/ISampleCapability.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.mqnaas.core.api.ICapability;
 
 /**

--- a/core/src/test/java/org/mqnaas/core/impl/ISampleMgmtCapability.java
+++ b/core/src/test/java/org/mqnaas/core/impl/ISampleMgmtCapability.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.util.List;
 
 import org.mqnaas.core.api.ICapability;

--- a/core/src/test/java/org/mqnaas/core/impl/ResourceCapabilityTreeTests.java
+++ b/core/src/test/java/org/mqnaas/core/impl/ResourceCapabilityTreeTests.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Arrays;

--- a/core/src/test/java/org/mqnaas/core/impl/Sample2Capability.java
+++ b/core/src/test/java/org/mqnaas/core/impl/Sample2Capability.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.mqnaas.core.api.exceptions.ApplicationActivationException;
 
 /**

--- a/core/src/test/java/org/mqnaas/core/impl/SampleApplication.java
+++ b/core/src/test/java/org/mqnaas/core/impl/SampleApplication.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.mqnaas.core.api.IApplication;
 import org.mqnaas.core.api.exceptions.ApplicationActivationException;
 import org.slf4j.Logger;

--- a/core/src/test/java/org/mqnaas/core/impl/SampleCapability.java
+++ b/core/src/test/java/org/mqnaas/core/impl/SampleCapability.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.mqnaas.core.api.IResource;
 import org.mqnaas.core.api.exceptions.ApplicationActivationException;
 

--- a/core/src/test/java/org/mqnaas/core/impl/SampleMgmtCapability.java
+++ b/core/src/test/java/org/mqnaas/core/impl/SampleMgmtCapability.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.util.ArrayList;
 import java.util.List;
 

--- a/core/src/test/java/org/mqnaas/core/impl/SampleResource.java
+++ b/core/src/test/java/org/mqnaas/core/impl/SampleResource.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.mqnaas.core.api.IResource;
 
 /**

--- a/core/src/test/java/org/mqnaas/core/impl/SampleService.java
+++ b/core/src/test/java/org/mqnaas/core/impl/SampleService.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.mqnaas.core.api.IResource;
 import org.mqnaas.core.api.IService;
 import org.mqnaas.core.api.IServiceMetaData;

--- a/core/src/test/java/org/mqnaas/core/impl/ScheduledJobTest.java
+++ b/core/src/test/java/org/mqnaas/core/impl/ScheduledJobTest.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.lang.reflect.InvocationTargetException;
 import java.util.HashMap;
 import java.util.Map;

--- a/core/src/test/java/org/mqnaas/core/impl/ServiceExecutionSchedulerTest.java
+++ b/core/src/test/java/org/mqnaas/core/impl/ServiceExecutionSchedulerTest.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.lang.reflect.InvocationTargetException;
 import java.util.Date;
 

--- a/core/src/test/java/org/mqnaas/core/impl/ServiceProviderImplTest.java
+++ b/core/src/test/java/org/mqnaas/core/impl/ServiceProviderImplTest.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/core/src/test/java/org/mqnaas/core/impl/dependencies/DependencyManagementTest.java
+++ b/core/src/test/java/org/mqnaas/core/impl/dependencies/DependencyManagementTest.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl.dependencies;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;

--- a/core/src/test/java/org/mqnaas/core/impl/dependencies/samples/App.java
+++ b/core/src/test/java/org/mqnaas/core/impl/dependencies/samples/App.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl.dependencies.samples;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.mqnaas.core.api.exceptions.ApplicationActivationException;
 
 public class App implements IApp {

--- a/core/src/test/java/org/mqnaas/core/impl/dependencies/samples/IApp.java
+++ b/core/src/test/java/org/mqnaas/core/impl/dependencies/samples/IApp.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl.dependencies.samples;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.mqnaas.core.api.IApplication;
 
 public interface IApp extends IApplication {

--- a/core/src/test/java/org/mqnaas/core/impl/dependencies/samples/IAppA.java
+++ b/core/src/test/java/org/mqnaas/core/impl/dependencies/samples/IAppA.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl.dependencies.samples;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 
 public interface IAppA extends IApp {
 

--- a/core/src/test/java/org/mqnaas/core/impl/dependencies/samples/IAppB.java
+++ b/core/src/test/java/org/mqnaas/core/impl/dependencies/samples/IAppB.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl.dependencies.samples;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 
 public interface IAppB extends IApp {
 

--- a/core/src/test/java/org/mqnaas/core/impl/dependencies/samples/IAppC.java
+++ b/core/src/test/java/org/mqnaas/core/impl/dependencies/samples/IAppC.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl.dependencies.samples;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 
 public interface IAppC extends IApp {
 

--- a/core/src/test/java/org/mqnaas/core/impl/dependencies/samples/IAppD.java
+++ b/core/src/test/java/org/mqnaas/core/impl/dependencies/samples/IAppD.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl.dependencies.samples;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 
 public interface IAppD extends IApp {
 

--- a/core/src/test/java/org/mqnaas/core/impl/dependencies/samples/IAppE.java
+++ b/core/src/test/java/org/mqnaas/core/impl/dependencies/samples/IAppE.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl.dependencies.samples;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 public interface IAppE extends IApp {
 
 	public void e();

--- a/core/src/test/java/org/mqnaas/core/impl/dependencies/samples/IAppF.java
+++ b/core/src/test/java/org/mqnaas/core/impl/dependencies/samples/IAppF.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl.dependencies.samples;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 public interface IAppF extends IApp {
 
 	public void f();

--- a/core/src/test/java/org/mqnaas/core/impl/dependencies/samples/_1_4inline/AppA.java
+++ b/core/src/test/java/org/mqnaas/core/impl/dependencies/samples/_1_4inline/AppA.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl.dependencies.samples._1_4inline;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.mqnaas.core.impl.dependencies.samples.App;
 import org.mqnaas.core.impl.dependencies.samples.IAppA;
 

--- a/core/src/test/java/org/mqnaas/core/impl/dependencies/samples/_1_4inline/AppB.java
+++ b/core/src/test/java/org/mqnaas/core/impl/dependencies/samples/_1_4inline/AppB.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl.dependencies.samples._1_4inline;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.mqnaas.core.api.annotations.DependingOn;
 import org.mqnaas.core.impl.dependencies.samples.App;
 import org.mqnaas.core.impl.dependencies.samples.IAppA;

--- a/core/src/test/java/org/mqnaas/core/impl/dependencies/samples/_1_4inline/AppC.java
+++ b/core/src/test/java/org/mqnaas/core/impl/dependencies/samples/_1_4inline/AppC.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl.dependencies.samples._1_4inline;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.mqnaas.core.api.annotations.DependingOn;
 import org.mqnaas.core.impl.dependencies.samples.App;
 import org.mqnaas.core.impl.dependencies.samples.IAppB;

--- a/core/src/test/java/org/mqnaas/core/impl/dependencies/samples/_1_4inline/AppD.java
+++ b/core/src/test/java/org/mqnaas/core/impl/dependencies/samples/_1_4inline/AppD.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl.dependencies.samples._1_4inline;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.mqnaas.core.api.annotations.DependingOn;
 import org.mqnaas.core.impl.dependencies.samples.App;
 import org.mqnaas.core.impl.dependencies.samples.IAppC;

--- a/core/src/test/java/org/mqnaas/core/impl/dependencies/samples/_1_4inline/ScenarioInitializer.java
+++ b/core/src/test/java/org/mqnaas/core/impl/dependencies/samples/_1_4inline/ScenarioInitializer.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl.dependencies.samples._1_4inline;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.util.ArrayList;
 import java.util.Collection;
 

--- a/core/src/test/java/org/mqnaas/core/impl/dependencies/samples/_2_tree/AppA.java
+++ b/core/src/test/java/org/mqnaas/core/impl/dependencies/samples/_2_tree/AppA.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl.dependencies.samples._2_tree;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.mqnaas.core.api.annotations.DependingOn;
 import org.mqnaas.core.impl.dependencies.samples.App;
 import org.mqnaas.core.impl.dependencies.samples.IAppA;

--- a/core/src/test/java/org/mqnaas/core/impl/dependencies/samples/_2_tree/AppB.java
+++ b/core/src/test/java/org/mqnaas/core/impl/dependencies/samples/_2_tree/AppB.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl.dependencies.samples._2_tree;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.mqnaas.core.api.annotations.DependingOn;
 import org.mqnaas.core.impl.dependencies.samples.App;
 import org.mqnaas.core.impl.dependencies.samples.IAppB;

--- a/core/src/test/java/org/mqnaas/core/impl/dependencies/samples/_2_tree/AppC.java
+++ b/core/src/test/java/org/mqnaas/core/impl/dependencies/samples/_2_tree/AppC.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl.dependencies.samples._2_tree;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.mqnaas.core.impl.dependencies.samples.App;
 import org.mqnaas.core.impl.dependencies.samples.IAppC;
 

--- a/core/src/test/java/org/mqnaas/core/impl/dependencies/samples/_2_tree/AppD.java
+++ b/core/src/test/java/org/mqnaas/core/impl/dependencies/samples/_2_tree/AppD.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl.dependencies.samples._2_tree;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.mqnaas.core.api.annotations.DependingOn;
 import org.mqnaas.core.impl.dependencies.samples.App;
 import org.mqnaas.core.impl.dependencies.samples.IAppD;

--- a/core/src/test/java/org/mqnaas/core/impl/dependencies/samples/_2_tree/AppE.java
+++ b/core/src/test/java/org/mqnaas/core/impl/dependencies/samples/_2_tree/AppE.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl.dependencies.samples._2_tree;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.mqnaas.core.impl.dependencies.samples.App;
 import org.mqnaas.core.impl.dependencies.samples.IAppE;
 

--- a/core/src/test/java/org/mqnaas/core/impl/dependencies/samples/_2_tree/ScenarioInitializer.java
+++ b/core/src/test/java/org/mqnaas/core/impl/dependencies/samples/_2_tree/ScenarioInitializer.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl.dependencies.samples._2_tree;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.util.ArrayList;
 import java.util.Collection;
 

--- a/core/src/test/java/org/mqnaas/core/impl/dependencies/samples/_3_cycle/AppA.java
+++ b/core/src/test/java/org/mqnaas/core/impl/dependencies/samples/_3_cycle/AppA.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl.dependencies.samples._3_cycle;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.mqnaas.core.api.annotations.DependingOn;
 import org.mqnaas.core.impl.dependencies.samples.App;
 import org.mqnaas.core.impl.dependencies.samples.IAppA;

--- a/core/src/test/java/org/mqnaas/core/impl/dependencies/samples/_3_cycle/AppB.java
+++ b/core/src/test/java/org/mqnaas/core/impl/dependencies/samples/_3_cycle/AppB.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl.dependencies.samples._3_cycle;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.mqnaas.core.api.annotations.DependingOn;
 import org.mqnaas.core.impl.dependencies.samples.App;
 import org.mqnaas.core.impl.dependencies.samples.IAppB;

--- a/core/src/test/java/org/mqnaas/core/impl/dependencies/samples/_3_cycle/AppC.java
+++ b/core/src/test/java/org/mqnaas/core/impl/dependencies/samples/_3_cycle/AppC.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl.dependencies.samples._3_cycle;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.mqnaas.core.api.annotations.DependingOn;
 import org.mqnaas.core.impl.dependencies.samples.App;
 import org.mqnaas.core.impl.dependencies.samples.IAppC;

--- a/core/src/test/java/org/mqnaas/core/impl/dependencies/samples/_3_cycle/ScenarioInitializer.java
+++ b/core/src/test/java/org/mqnaas/core/impl/dependencies/samples/_3_cycle/ScenarioInitializer.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl.dependencies.samples._3_cycle;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.util.ArrayList;
 import java.util.Collection;
 

--- a/core/src/test/java/org/mqnaas/core/impl/dependencies/samples/_4_multicycle/AppAF.java
+++ b/core/src/test/java/org/mqnaas/core/impl/dependencies/samples/_4_multicycle/AppAF.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl.dependencies.samples._4_multicycle;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.mqnaas.core.api.annotations.DependingOn;
 import org.mqnaas.core.impl.dependencies.samples.App;
 import org.mqnaas.core.impl.dependencies.samples.IAppA;

--- a/core/src/test/java/org/mqnaas/core/impl/dependencies/samples/_4_multicycle/AppB.java
+++ b/core/src/test/java/org/mqnaas/core/impl/dependencies/samples/_4_multicycle/AppB.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl.dependencies.samples._4_multicycle;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.mqnaas.core.api.annotations.DependingOn;
 import org.mqnaas.core.impl.dependencies.samples.App;
 import org.mqnaas.core.impl.dependencies.samples.IAppB;

--- a/core/src/test/java/org/mqnaas/core/impl/dependencies/samples/_4_multicycle/AppC.java
+++ b/core/src/test/java/org/mqnaas/core/impl/dependencies/samples/_4_multicycle/AppC.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl.dependencies.samples._4_multicycle;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.mqnaas.core.api.annotations.DependingOn;
 import org.mqnaas.core.impl.dependencies.samples.App;
 import org.mqnaas.core.impl.dependencies.samples.IAppC;

--- a/core/src/test/java/org/mqnaas/core/impl/dependencies/samples/_4_multicycle/AppDE.java
+++ b/core/src/test/java/org/mqnaas/core/impl/dependencies/samples/_4_multicycle/AppDE.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl.dependencies.samples._4_multicycle;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.mqnaas.core.api.annotations.DependingOn;
 import org.mqnaas.core.impl.dependencies.samples.App;
 import org.mqnaas.core.impl.dependencies.samples.IAppD;

--- a/core/src/test/java/org/mqnaas/core/impl/dependencies/samples/_4_multicycle/ScenarioInitializer.java
+++ b/core/src/test/java/org/mqnaas/core/impl/dependencies/samples/_4_multicycle/ScenarioInitializer.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl.dependencies.samples._4_multicycle;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.util.ArrayList;
 import java.util.Collection;
 

--- a/core/src/test/java/org/mqnaas/core/impl/dependencies/samples/_5_minicycle/AppA.java
+++ b/core/src/test/java/org/mqnaas/core/impl/dependencies/samples/_5_minicycle/AppA.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl.dependencies.samples._5_minicycle;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.mqnaas.core.api.annotations.DependingOn;
 import org.mqnaas.core.impl.dependencies.samples.App;
 import org.mqnaas.core.impl.dependencies.samples.IAppA;

--- a/core/src/test/java/org/mqnaas/core/impl/dependencies/samples/_5_minicycle/AppB.java
+++ b/core/src/test/java/org/mqnaas/core/impl/dependencies/samples/_5_minicycle/AppB.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl.dependencies.samples._5_minicycle;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.mqnaas.core.api.annotations.DependingOn;
 import org.mqnaas.core.impl.dependencies.samples.App;
 import org.mqnaas.core.impl.dependencies.samples.IAppA;

--- a/core/src/test/java/org/mqnaas/core/impl/dependencies/samples/_5_minicycle/ScenarioInitializer.java
+++ b/core/src/test/java/org/mqnaas/core/impl/dependencies/samples/_5_minicycle/ScenarioInitializer.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl.dependencies.samples._5_minicycle;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.util.ArrayList;
 import java.util.Collection;
 

--- a/core/src/test/java/org/mqnaas/core/impl/dependencies/samples/_6_4cycle/AppA.java
+++ b/core/src/test/java/org/mqnaas/core/impl/dependencies/samples/_6_4cycle/AppA.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl.dependencies.samples._6_4cycle;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.mqnaas.core.api.annotations.DependingOn;
 import org.mqnaas.core.impl.dependencies.samples.App;
 import org.mqnaas.core.impl.dependencies.samples.IAppA;

--- a/core/src/test/java/org/mqnaas/core/impl/dependencies/samples/_6_4cycle/AppB.java
+++ b/core/src/test/java/org/mqnaas/core/impl/dependencies/samples/_6_4cycle/AppB.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl.dependencies.samples._6_4cycle;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.mqnaas.core.api.annotations.DependingOn;
 import org.mqnaas.core.impl.dependencies.samples.App;
 import org.mqnaas.core.impl.dependencies.samples.IAppB;

--- a/core/src/test/java/org/mqnaas/core/impl/dependencies/samples/_6_4cycle/AppC.java
+++ b/core/src/test/java/org/mqnaas/core/impl/dependencies/samples/_6_4cycle/AppC.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl.dependencies.samples._6_4cycle;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.mqnaas.core.api.annotations.DependingOn;
 import org.mqnaas.core.impl.dependencies.samples.App;
 import org.mqnaas.core.impl.dependencies.samples.IAppC;

--- a/core/src/test/java/org/mqnaas/core/impl/dependencies/samples/_6_4cycle/AppD.java
+++ b/core/src/test/java/org/mqnaas/core/impl/dependencies/samples/_6_4cycle/AppD.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl.dependencies.samples._6_4cycle;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.mqnaas.core.api.annotations.DependingOn;
 import org.mqnaas.core.impl.dependencies.samples.App;
 import org.mqnaas.core.impl.dependencies.samples.IAppD;

--- a/core/src/test/java/org/mqnaas/core/impl/dependencies/samples/_6_4cycle/AppE.java
+++ b/core/src/test/java/org/mqnaas/core/impl/dependencies/samples/_6_4cycle/AppE.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl.dependencies.samples._6_4cycle;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.mqnaas.core.api.annotations.DependingOn;
 import org.mqnaas.core.impl.dependencies.samples.App;
 import org.mqnaas.core.impl.dependencies.samples.IAppB;

--- a/core/src/test/java/org/mqnaas/core/impl/dependencies/samples/_6_4cycle/ScenarioInitializer.java
+++ b/core/src/test/java/org/mqnaas/core/impl/dependencies/samples/_6_4cycle/ScenarioInitializer.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl.dependencies.samples._6_4cycle;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.util.ArrayList;
 import java.util.Collection;
 

--- a/core/src/test/java/org/mqnaas/core/impl/dependencies/samples/_7_multipleimpl/AppA.java
+++ b/core/src/test/java/org/mqnaas/core/impl/dependencies/samples/_7_multipleimpl/AppA.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl.dependencies.samples._7_multipleimpl;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.mqnaas.core.api.annotations.DependingOn;
 import org.mqnaas.core.impl.dependencies.samples.App;
 import org.mqnaas.core.impl.dependencies.samples.IAppA;

--- a/core/src/test/java/org/mqnaas/core/impl/dependencies/samples/_7_multipleimpl/AppB1.java
+++ b/core/src/test/java/org/mqnaas/core/impl/dependencies/samples/_7_multipleimpl/AppB1.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl.dependencies.samples._7_multipleimpl;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.mqnaas.core.impl.dependencies.samples.App;
 import org.mqnaas.core.impl.dependencies.samples.IAppB;
 

--- a/core/src/test/java/org/mqnaas/core/impl/dependencies/samples/_7_multipleimpl/AppB2.java
+++ b/core/src/test/java/org/mqnaas/core/impl/dependencies/samples/_7_multipleimpl/AppB2.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl.dependencies.samples._7_multipleimpl;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.mqnaas.core.impl.dependencies.samples.App;
 import org.mqnaas.core.impl.dependencies.samples.IAppB;
 

--- a/core/src/test/java/org/mqnaas/core/impl/dependencies/samples/_7_multipleimpl/ScenarioInitializer.java
+++ b/core/src/test/java/org/mqnaas/core/impl/dependencies/samples/_7_multipleimpl/ScenarioInitializer.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl.dependencies.samples._7_multipleimpl;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.util.ArrayList;
 import java.util.Collection;
 

--- a/core/src/test/java/org/mqnaas/core/impl/dummy/DummyBundleGuard.java
+++ b/core/src/test/java/org/mqnaas/core/impl/dummy/DummyBundleGuard.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl.dummy;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.mqnaas.bundletree.IBundleGuard;
 import org.mqnaas.bundletree.IClassFilter;
 import org.mqnaas.bundletree.IClassListener;

--- a/core/src/test/java/org/mqnaas/core/impl/dummy/DummyExecutionService.java
+++ b/core/src/test/java/org/mqnaas/core/impl/dummy/DummyExecutionService.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl.dummy;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.mqnaas.core.api.IExecutionService;
 import org.mqnaas.core.api.IService;
 

--- a/core/src/test/java/org/mqnaas/core/impl/slicing/SliceAdministrationTest.java
+++ b/core/src/test/java/org/mqnaas/core/impl/slicing/SliceAdministrationTest.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl.slicing;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;

--- a/core/src/test/java/org/mqnaas/core/impl/slicing/UnitSerializationTest.java
+++ b/core/src/test/java/org/mqnaas/core/impl/slicing/UnitSerializationTest.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl.slicing;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.io.IOException;
 
 import javax.xml.bind.JAXBException;

--- a/core/src/test/java/org/mqnaas/core/impl/utils/ReflectionUtilsTests.java
+++ b/core/src/test/java/org/mqnaas/core/impl/utils/ReflectionUtilsTests.java
@@ -1,5 +1,27 @@
 package org.mqnaas.core.impl.utils;
 
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;

--- a/extensions/LICENSE
+++ b/extensions/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/extensions/network/itests/src/test/java/org/mqnaas/extensions/network/itests/NetworkManagementTest.java
+++ b/extensions/network/itests/src/test/java/org/mqnaas/extensions/network/itests/NetworkManagementTest.java
@@ -1,5 +1,26 @@
 package org.mqnaas.extensions.network.itests;
 
+/*
+ * #%L
+ * MQNaaS :: Network Integration Tests
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i
+ * 			Innovació a Catalunya
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import java.io.File;
 import java.net.URI;
 import java.net.URISyntaxException;

--- a/extensions/network/itests/src/test/java/org/mqnaas/extensions/network/itests/ResourcesIntegrationTest.java
+++ b/extensions/network/itests/src/test/java/org/mqnaas/extensions/network/itests/ResourcesIntegrationTest.java
@@ -1,5 +1,26 @@
 package org.mqnaas.extensions.network.itests;
 
+/*
+ * #%L
+ * MQNaaS :: Network Integration Tests
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i
+ * 			Innovació a Catalunya
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import java.io.File;
 import java.util.Arrays;
 

--- a/extensions/network/network-test-helpers/src/main/java/org/mqnaas/extensions/network/itests/helpers/DummySlicingCapability.java
+++ b/extensions/network/network-test-helpers/src/main/java/org/mqnaas/extensions/network/itests/helpers/DummySlicingCapability.java
@@ -1,5 +1,26 @@
 package org.mqnaas.extensions.network.itests.helpers;
 
+/*
+ * #%L
+ * MQNaaS :: Network :: iTests Helpers
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i
+ * 			Innovació a Catalunya
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import java.util.ArrayList;
 import java.util.Collection;
 

--- a/extensions/network/network.api/src/main/java/org/mqnaas/network/api/IBaseNetworkManagement.java
+++ b/extensions/network/network.api/src/main/java/org/mqnaas/network/api/IBaseNetworkManagement.java
@@ -1,5 +1,26 @@
 package org.mqnaas.network.api;
 
+/*
+ * #%L
+ * MQNaaS :: Network API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i
+ * 			Innovació a Catalunya
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import java.util.Collection;
 
 import org.mqnaas.core.api.IRootResource;

--- a/extensions/network/network.api/src/main/java/org/mqnaas/network/api/INetworkManagement.java
+++ b/extensions/network/network.api/src/main/java/org/mqnaas/network/api/INetworkManagement.java
@@ -1,5 +1,26 @@
 package org.mqnaas.network.api;
 
+/*
+ * #%L
+ * MQNaaS :: Network API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i
+ * 			Innovació a Catalunya
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import org.mqnaas.core.api.IResource;
 import org.mqnaas.core.api.IRootResource;
 import org.mqnaas.core.api.annotations.AddsResource;

--- a/extensions/network/network.api/src/main/java/org/mqnaas/network/api/exceptions/NetworkCreationException.java
+++ b/extensions/network/network.api/src/main/java/org/mqnaas/network/api/exceptions/NetworkCreationException.java
@@ -1,5 +1,26 @@
 package org.mqnaas.network.api.exceptions;
 
+/*
+ * #%L
+ * MQNaaS :: Network API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i
+ * 			Innovació a Catalunya
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import org.mqnaas.network.api.request.IRequestResourceManagement;
 
 /**

--- a/extensions/network/network.api/src/main/java/org/mqnaas/network/api/exceptions/NetworkReleaseException.java
+++ b/extensions/network/network.api/src/main/java/org/mqnaas/network/api/exceptions/NetworkReleaseException.java
@@ -1,5 +1,26 @@
 package org.mqnaas.network.api.exceptions;
 
+/*
+ * #%L
+ * MQNaaS :: Network API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i
+ * 			Innovació a Catalunya
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import org.mqnaas.network.api.request.IRequestBasedNetworkManagement;
 
 /**

--- a/extensions/network/network.api/src/main/java/org/mqnaas/network/api/request/DateAdapter.java
+++ b/extensions/network/network.api/src/main/java/org/mqnaas/network/api/request/DateAdapter.java
@@ -1,5 +1,26 @@
 package org.mqnaas.network.api.request;
 
+/*
+ * #%L
+ * MQNaaS :: Network API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i
+ * 			Innovació a Catalunya
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;

--- a/extensions/network/network.api/src/main/java/org/mqnaas/network/api/request/IRequestAdministration.java
+++ b/extensions/network/network.api/src/main/java/org/mqnaas/network/api/request/IRequestAdministration.java
@@ -1,5 +1,26 @@
 package org.mqnaas.network.api.request;
 
+/*
+ * #%L
+ * MQNaaS :: Network API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i
+ * 			Innovació a Catalunya
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import org.mqnaas.core.api.ICapability;
 
 /**

--- a/extensions/network/network.api/src/main/java/org/mqnaas/network/api/request/IRequestBasedNetworkManagement.java
+++ b/extensions/network/network.api/src/main/java/org/mqnaas/network/api/request/IRequestBasedNetworkManagement.java
@@ -1,5 +1,26 @@
 package org.mqnaas.network.api.request;
 
+/*
+ * #%L
+ * MQNaaS :: Network API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i
+ * 			Innovació a Catalunya
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import org.mqnaas.core.api.ICapability;
 import org.mqnaas.core.api.IResource;
 import org.mqnaas.core.api.IRootResource;

--- a/extensions/network/network.api/src/main/java/org/mqnaas/network/api/request/IRequestManagement.java
+++ b/extensions/network/network.api/src/main/java/org/mqnaas/network/api/request/IRequestManagement.java
@@ -1,5 +1,26 @@
 package org.mqnaas.network.api.request;
 
+/*
+ * #%L
+ * MQNaaS :: Network API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i
+ * 			Innovació a Catalunya
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import java.util.List;
 
 import org.mqnaas.core.api.ICapability;

--- a/extensions/network/network.api/src/main/java/org/mqnaas/network/api/request/IRequestResourceManagement.java
+++ b/extensions/network/network.api/src/main/java/org/mqnaas/network/api/request/IRequestResourceManagement.java
@@ -1,5 +1,26 @@
 package org.mqnaas.network.api.request;
 
+/*
+ * #%L
+ * MQNaaS :: Network API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i
+ * 			Innovació a Catalunya
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import java.util.List;
 
 import org.mqnaas.core.api.ICapability;

--- a/extensions/network/network.api/src/main/java/org/mqnaas/network/api/request/IRequestResourceMapping.java
+++ b/extensions/network/network.api/src/main/java/org/mqnaas/network/api/request/IRequestResourceMapping.java
@@ -1,5 +1,26 @@
 package org.mqnaas.network.api.request;
 
+/*
+ * #%L
+ * MQNaaS :: Network API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i
+ * 			Innovació a Catalunya
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import java.util.Collection;
 
 import org.mqnaas.core.api.ICapability;

--- a/extensions/network/network.api/src/main/java/org/mqnaas/network/api/request/Period.java
+++ b/extensions/network/network.api/src/main/java/org/mqnaas/network/api/request/Period.java
@@ -1,5 +1,26 @@
 package org.mqnaas.network.api.request;
 
+/*
+ * #%L
+ * MQNaaS :: Network API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i
+ * 			Innovació a Catalunya
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import java.util.Date;
 
 import javax.xml.bind.annotation.XmlAccessType;

--- a/extensions/network/network.api/src/main/java/org/mqnaas/network/api/reservation/IReservationAdministration.java
+++ b/extensions/network/network.api/src/main/java/org/mqnaas/network/api/reservation/IReservationAdministration.java
@@ -1,5 +1,26 @@
 package org.mqnaas.network.api.reservation;
 
+/*
+ * #%L
+ * MQNaaS :: Network API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i
+ * 			Innovació a Catalunya
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import java.util.Set;
 
 import org.mqnaas.core.api.ICapability;

--- a/extensions/network/network.api/src/main/java/org/mqnaas/network/api/reservation/IReservationManagement.java
+++ b/extensions/network/network.api/src/main/java/org/mqnaas/network/api/reservation/IReservationManagement.java
@@ -1,5 +1,26 @@
 package org.mqnaas.network.api.reservation;
 
+/*
+ * #%L
+ * MQNaaS :: Network API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i
+ * 			Innovació a Catalunya
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import java.util.List;
 
 import org.mqnaas.core.api.ICapability;

--- a/extensions/network/network.api/src/main/java/org/mqnaas/network/api/reservation/IReservationPerformer.java
+++ b/extensions/network/network.api/src/main/java/org/mqnaas/network/api/reservation/IReservationPerformer.java
@@ -1,5 +1,26 @@
 package org.mqnaas.network.api.reservation;
 
+/*
+ * #%L
+ * MQNaaS :: Network API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i
+ * 			Innovació a Catalunya
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import org.mqnaas.core.api.ICapability;
 
 /**

--- a/extensions/network/network.api/src/main/java/org/mqnaas/network/api/reservation/IReservationPlanner.java
+++ b/extensions/network/network.api/src/main/java/org/mqnaas/network/api/reservation/IReservationPlanner.java
@@ -1,5 +1,26 @@
 package org.mqnaas.network.api.reservation;
 
+/*
+ * #%L
+ * MQNaaS :: Network API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i
+ * 			Innovació a Catalunya
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import org.mqnaas.core.api.ICapability;
 import org.mqnaas.core.api.IRootResource;
 import org.mqnaas.network.api.request.Period;

--- a/extensions/network/network.api/src/main/java/org/mqnaas/network/api/reservation/ReservationResource.java
+++ b/extensions/network/network.api/src/main/java/org/mqnaas/network/api/reservation/ReservationResource.java
@@ -1,5 +1,26 @@
 package org.mqnaas.network.api.reservation;
 
+/*
+ * #%L
+ * MQNaaS :: Network API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i
+ * 			Innovació a Catalunya
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.xml.bind.annotation.XmlAccessType;

--- a/extensions/network/network.api/src/main/java/org/mqnaas/network/api/reservation/ResourceReservationException.java
+++ b/extensions/network/network.api/src/main/java/org/mqnaas/network/api/reservation/ResourceReservationException.java
@@ -1,5 +1,26 @@
 package org.mqnaas.network.api.reservation;
 
+/*
+ * #%L
+ * MQNaaS :: Network API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i
+ * 			Innovació a Catalunya
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 /**
  * 
  * @author Adrián Roselló Rey (i2CAT)

--- a/extensions/network/network.api/src/main/java/org/mqnaas/network/api/topology/link/ILinkAdministration.java
+++ b/extensions/network/network.api/src/main/java/org/mqnaas/network/api/topology/link/ILinkAdministration.java
@@ -1,5 +1,26 @@
 package org.mqnaas.network.api.topology.link;
 
+/*
+ * #%L
+ * MQNaaS :: Network API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i
+ * 			Innovació a Catalunya
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import org.mqnaas.core.api.ICapability;
 import org.mqnaas.core.api.IResource;
 

--- a/extensions/network/network.api/src/main/java/org/mqnaas/network/api/topology/link/ILinkManagement.java
+++ b/extensions/network/network.api/src/main/java/org/mqnaas/network/api/topology/link/ILinkManagement.java
@@ -1,5 +1,26 @@
 package org.mqnaas.network.api.topology.link;
 
+/*
+ * #%L
+ * MQNaaS :: Network API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i
+ * 			Innovació a Catalunya
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import java.util.List;
 
 import org.mqnaas.core.api.ICapability;

--- a/extensions/network/network.api/src/main/java/org/mqnaas/network/api/topology/port/INetworkPortManagement.java
+++ b/extensions/network/network.api/src/main/java/org/mqnaas/network/api/topology/port/INetworkPortManagement.java
@@ -1,5 +1,26 @@
 package org.mqnaas.network.api.topology.port;
 
+/*
+ * #%L
+ * MQNaaS :: Network API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i
+ * 			Innovació a Catalunya
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import java.util.List;
 
 import org.mqnaas.core.api.ICapability;

--- a/extensions/network/network.api/src/main/java/org/mqnaas/network/api/topology/port/IPortAdministration.java
+++ b/extensions/network/network.api/src/main/java/org/mqnaas/network/api/topology/port/IPortAdministration.java
@@ -1,5 +1,26 @@
 package org.mqnaas.network.api.topology.port;
 
+/*
+ * #%L
+ * MQNaaS :: Network API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i
+ * 			Innovació a Catalunya
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import org.mqnaas.core.api.ICapability;
 
 /**

--- a/extensions/network/network.api/src/main/java/org/mqnaas/network/api/topology/port/IPortManagement.java
+++ b/extensions/network/network.api/src/main/java/org/mqnaas/network/api/topology/port/IPortManagement.java
@@ -1,5 +1,26 @@
 package org.mqnaas.network.api.topology.port;
 
+/*
+ * #%L
+ * MQNaaS :: Network API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i
+ * 			Innovació a Catalunya
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import java.util.List;
 
 import org.mqnaas.core.api.ICapability;

--- a/extensions/network/network.api/src/test/java/org/mqnaas/network/api/PeriodSerializationTest.java
+++ b/extensions/network/network.api/src/test/java/org/mqnaas/network/api/PeriodSerializationTest.java
@@ -1,5 +1,26 @@
 package org.mqnaas.network.api;
 
+/*
+ * #%L
+ * MQNaaS :: Network API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i
+ * 			Innovació a Catalunya
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import java.io.IOException;
 import java.util.Date;
 import java.util.GregorianCalendar;

--- a/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/Link.java
+++ b/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/Link.java
@@ -1,5 +1,26 @@
 package org.mqnaas.network.impl;
 
+/*
+ * #%L
+ * MQNaaS :: Network Implementation
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i
+ * 			Innovació a Catalunya
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import org.mqnaas.core.api.IResource;
 import org.mqnaas.core.api.IServiceProvider;
 import org.mqnaas.core.api.exceptions.CapabilityNotFoundException;

--- a/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/Network.java
+++ b/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/Network.java
@@ -1,5 +1,26 @@
 package org.mqnaas.network.impl;
 
+/*
+ * #%L
+ * MQNaaS :: Network Implementation
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i
+ * 			Innovació a Catalunya
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import java.util.Collection;
 import java.util.List;
 

--- a/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/NetworkManagement.java
+++ b/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/NetworkManagement.java
@@ -1,5 +1,26 @@
 package org.mqnaas.network.impl;
 
+/*
+ * #%L
+ * MQNaaS :: Network Implementation
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i
+ * 			Innovació a Catalunya
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;

--- a/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/NetworkRootResourceProvider.java
+++ b/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/NetworkRootResourceProvider.java
@@ -1,5 +1,26 @@
 package org.mqnaas.network.impl;
 
+/*
+ * #%L
+ * MQNaaS :: Network Implementation
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i
+ * 			Innovació a Catalunya
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;

--- a/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/NetworkSubResource.java
+++ b/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/NetworkSubResource.java
@@ -1,5 +1,26 @@
 package org.mqnaas.network.impl;
 
+/*
+ * #%L
+ * MQNaaS :: Network Implementation
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i
+ * 			Innovació a Catalunya
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import java.util.List;
 
 import org.mqnaas.core.api.ICapability;

--- a/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/PortResourceWrapper.java
+++ b/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/PortResourceWrapper.java
@@ -1,5 +1,26 @@
 package org.mqnaas.network.impl;
 
+/*
+ * #%L
+ * MQNaaS :: Network Implementation
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i
+ * 			Innovació a Catalunya
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import org.mqnaas.core.api.IAttributeStore;
 import org.mqnaas.core.api.IResource;
 import org.mqnaas.core.api.IServiceProvider;

--- a/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/request/Request.java
+++ b/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/request/Request.java
@@ -1,5 +1,26 @@
 package org.mqnaas.network.impl.request;
 
+/*
+ * #%L
+ * MQNaaS :: Network Implementation
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i
+ * 			Innovació a Catalunya
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import java.util.Collection;
 import java.util.List;
 

--- a/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/request/RequestAdministration.java
+++ b/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/request/RequestAdministration.java
@@ -1,5 +1,26 @@
 package org.mqnaas.network.impl.request;
 
+/*
+ * #%L
+ * MQNaaS :: Network Implementation
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i
+ * 			Innovació a Catalunya
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import org.mqnaas.core.api.IResource;
 import org.mqnaas.core.api.annotations.Resource;
 import org.mqnaas.core.api.exceptions.ApplicationActivationException;

--- a/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/request/RequestManagement.java
+++ b/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/request/RequestManagement.java
@@ -1,5 +1,26 @@
 package org.mqnaas.network.impl.request;
 
+/*
+ * #%L
+ * MQNaaS :: Network Implementation
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i
+ * 			Innovació a Catalunya
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;

--- a/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/request/RequestResource.java
+++ b/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/request/RequestResource.java
@@ -1,5 +1,26 @@
 package org.mqnaas.network.impl.request;
 
+/*
+ * #%L
+ * MQNaaS :: Network Implementation
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i
+ * 			Innovació a Catalunya
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.mqnaas.core.api.IResource;

--- a/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/request/RequestResourceManagement.java
+++ b/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/request/RequestResourceManagement.java
@@ -1,5 +1,26 @@
 package org.mqnaas.network.impl.request;
 
+/*
+ * #%L
+ * MQNaaS :: Network Implementation
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i
+ * 			Innovació a Catalunya
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;

--- a/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/request/RequestResourceMapping.java
+++ b/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/request/RequestResourceMapping.java
@@ -1,5 +1,26 @@
 package org.mqnaas.network.impl.request;
 
+/*
+ * #%L
+ * MQNaaS :: Network Implementation
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i
+ * 			Innovació a Catalunya
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;

--- a/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/request/RequestRootResource.java
+++ b/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/request/RequestRootResource.java
@@ -1,5 +1,26 @@
 package org.mqnaas.network.impl.request;
 
+/*
+ * #%L
+ * MQNaaS :: Network Implementation
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i
+ * 			Innovació a Catalunya
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.mqnaas.core.api.IResource;

--- a/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/reservation/ReservationAdministration.java
+++ b/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/reservation/ReservationAdministration.java
@@ -1,5 +1,26 @@
 package org.mqnaas.network.impl.reservation;
 
+/*
+ * #%L
+ * MQNaaS :: Network Implementation
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i
+ * 			Innovació a Catalunya
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import java.util.Set;
 
 import org.mqnaas.core.api.IResource;

--- a/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/reservation/ReservationManagement.java
+++ b/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/reservation/ReservationManagement.java
@@ -1,5 +1,26 @@
 package org.mqnaas.network.impl.reservation;
 
+/*
+ * #%L
+ * MQNaaS :: Network Implementation
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i
+ * 			Innovació a Catalunya
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashSet;

--- a/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/reservation/ReservationPerformer.java
+++ b/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/reservation/ReservationPerformer.java
@@ -1,5 +1,26 @@
 package org.mqnaas.network.impl.reservation;
 
+/*
+ * #%L
+ * MQNaaS :: Network Implementation
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i
+ * 			Innovació a Catalunya
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;

--- a/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/reservation/ReservationUtils.java
+++ b/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/reservation/ReservationUtils.java
@@ -1,5 +1,26 @@
 package org.mqnaas.network.impl.reservation;
 
+/*
+ * #%L
+ * MQNaaS :: Network Implementation
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i
+ * 			Innovació a Catalunya
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import org.mqnaas.core.api.IRootResource;
 import org.mqnaas.network.api.request.Period;
 import org.mqnaas.network.api.reservation.IReservationAdministration;

--- a/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/topology/link/Link.java
+++ b/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/topology/link/Link.java
@@ -1,5 +1,26 @@
 package org.mqnaas.network.impl.topology.link;
 
+/*
+ * #%L
+ * MQNaaS :: Network Implementation
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i
+ * 			Innovació a Catalunya
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import org.mqnaas.core.api.IResource;
 import org.mqnaas.core.api.IServiceProvider;
 import org.mqnaas.core.api.exceptions.CapabilityNotFoundException;

--- a/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/topology/link/LinkAdministration.java
+++ b/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/topology/link/LinkAdministration.java
@@ -1,5 +1,26 @@
 package org.mqnaas.network.impl.topology.link;
 
+/*
+ * #%L
+ * MQNaaS :: Network Implementation
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i
+ * 			Innovació a Catalunya
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import org.mqnaas.core.api.IResource;
 import org.mqnaas.core.api.IResourceManagementListener;
 import org.mqnaas.core.api.annotations.DependingOn;

--- a/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/topology/link/LinkManagement.java
+++ b/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/topology/link/LinkManagement.java
@@ -1,5 +1,26 @@
 package org.mqnaas.network.impl.topology.link;
 
+/*
+ * #%L
+ * MQNaaS :: Network Implementation
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i
+ * 			Innovació a Catalunya
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;

--- a/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/topology/link/LinkResource.java
+++ b/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/topology/link/LinkResource.java
@@ -1,5 +1,26 @@
 package org.mqnaas.network.impl.topology.link;
 
+/*
+ * #%L
+ * MQNaaS :: Network Implementation
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i
+ * 			Innovació a Catalunya
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.xml.bind.annotation.XmlAccessType;

--- a/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/topology/port/NetworkPortManagement.java
+++ b/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/topology/port/NetworkPortManagement.java
@@ -1,5 +1,26 @@
 package org.mqnaas.network.impl.topology.port;
 
+/*
+ * #%L
+ * MQNaaS :: Network Implementation
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i
+ * 			Innovació a Catalunya
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;

--- a/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/topology/port/Port.java
+++ b/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/topology/port/Port.java
@@ -1,5 +1,26 @@
 package org.mqnaas.network.impl.topology.port;
 
+/*
+ * #%L
+ * MQNaaS :: Network Implementation
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i
+ * 			Innovació a Catalunya
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import org.mqnaas.core.api.IResource;
 import org.mqnaas.core.api.IServiceProvider;
 import org.mqnaas.core.api.exceptions.CapabilityNotFoundException;

--- a/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/topology/port/PortManagement.java
+++ b/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/topology/port/PortManagement.java
@@ -1,5 +1,26 @@
 package org.mqnaas.network.impl.topology.port;
 
+/*
+ * #%L
+ * MQNaaS :: Network Implementation
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i
+ * 			Innovació a Catalunya
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;

--- a/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/topology/port/PortResource.java
+++ b/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/topology/port/PortResource.java
@@ -1,5 +1,26 @@
 package org.mqnaas.network.impl.topology.port;
 
+/*
+ * #%L
+ * MQNaaS :: Network Implementation
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i
+ * 			Innovació a Catalunya
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.xml.bind.annotation.XmlAccessType;

--- a/extensions/network/network.impl/src/test/java/org/mqnaas/network/impl/NetworkManagementTest.java
+++ b/extensions/network/network.impl/src/test/java/org/mqnaas/network/impl/NetworkManagementTest.java
@@ -1,5 +1,26 @@
 package org.mqnaas.network.impl;
 
+/*
+ * #%L
+ * MQNaaS :: Network Implementation
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i
+ * 			Innovació a Catalunya
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.URI;

--- a/extensions/network/network.impl/src/test/java/org/mqnaas/network/impl/reservation/ReservationManagementTest.java
+++ b/extensions/network/network.impl/src/test/java/org/mqnaas/network/impl/reservation/ReservationManagementTest.java
@@ -1,5 +1,26 @@
 package org.mqnaas.network.impl.reservation;
 
+/*
+ * #%L
+ * MQNaaS :: Network Implementation
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i
+ * 			Innovació a Catalunya
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Arrays;

--- a/extensions/network/network.impl/src/test/java/org/mqnaas/network/impl/reservation/ReservationPerformerTest.java
+++ b/extensions/network/network.impl/src/test/java/org/mqnaas/network/impl/reservation/ReservationPerformerTest.java
@@ -1,5 +1,26 @@
 package org.mqnaas.network.impl.reservation;
 
+/*
+ * #%L
+ * MQNaaS :: Network Implementation
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i
+ * 			Innovació a Catalunya
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Arrays;

--- a/extensions/network/network.impl/src/test/java/org/mqnaas/network/impl/reservation/ReservationUtilsTest.java
+++ b/extensions/network/network.impl/src/test/java/org/mqnaas/network/impl/reservation/ReservationUtilsTest.java
@@ -1,5 +1,26 @@
 package org.mqnaas.network.impl.reservation;
 
+/*
+ * #%L
+ * MQNaaS :: Network Implementation
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i
+ * 			Innovació a Catalunya
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Arrays;

--- a/extensions/odl/client/src/main/java/org/mqnaas/extensions/odl/client/switchnorthbound/ISwitchNorthboundAPI.java
+++ b/extensions/odl/client/src/main/java/org/mqnaas/extensions/odl/client/switchnorthbound/ISwitchNorthboundAPI.java
@@ -1,5 +1,26 @@
 package org.mqnaas.extensions.odl.client.switchnorthbound;
 
+/*
+ * #%L
+ * MQNaaS :: ODL Client
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i
+ * 			Innovació a Catalunya
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;

--- a/extensions/odl/client/src/main/java/org/mqnaas/extensions/odl/client/switchnorthbound/api/Node.java
+++ b/extensions/odl/client/src/main/java/org/mqnaas/extensions/odl/client/switchnorthbound/api/Node.java
@@ -1,5 +1,26 @@
 package org.mqnaas.extensions.odl.client.switchnorthbound.api;
 
+/*
+ * #%L
+ * MQNaaS :: ODL Client
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i
+ * 			Innovació a Catalunya
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;

--- a/extensions/odl/client/src/main/java/org/mqnaas/extensions/odl/client/switchnorthbound/api/NodeConnector.java
+++ b/extensions/odl/client/src/main/java/org/mqnaas/extensions/odl/client/switchnorthbound/api/NodeConnector.java
@@ -1,5 +1,26 @@
 package org.mqnaas.extensions.odl.client.switchnorthbound.api;
 
+/*
+ * #%L
+ * MQNaaS :: ODL Client
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i
+ * 			Innovació a Catalunya
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;

--- a/extensions/odl/client/src/main/java/org/mqnaas/extensions/odl/client/switchnorthbound/api/NodeConnectorProperties.java
+++ b/extensions/odl/client/src/main/java/org/mqnaas/extensions/odl/client/switchnorthbound/api/NodeConnectorProperties.java
@@ -1,5 +1,26 @@
 package org.mqnaas.extensions.odl.client.switchnorthbound.api;
 
+/*
+ * #%L
+ * MQNaaS :: ODL Client
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i
+ * 			Innovació a Catalunya
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import java.util.Map;
 
 import javax.xml.bind.annotation.XmlAccessType;

--- a/extensions/odl/client/src/main/java/org/mqnaas/extensions/odl/client/switchnorthbound/api/NodeConnectors.java
+++ b/extensions/odl/client/src/main/java/org/mqnaas/extensions/odl/client/switchnorthbound/api/NodeConnectors.java
@@ -1,5 +1,26 @@
 package org.mqnaas.extensions.odl.client.switchnorthbound.api;
 
+/*
+ * #%L
+ * MQNaaS :: ODL Client
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i
+ * 			Innovació a Catalunya
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import java.util.List;
 
 import javax.xml.bind.annotation.XmlAccessType;

--- a/extensions/odl/client/src/main/java/org/mqnaas/extensions/odl/client/switchnorthbound/api/NodeProperties.java
+++ b/extensions/odl/client/src/main/java/org/mqnaas/extensions/odl/client/switchnorthbound/api/NodeProperties.java
@@ -1,5 +1,26 @@
 package org.mqnaas.extensions.odl.client.switchnorthbound.api;
 
+/*
+ * #%L
+ * MQNaaS :: ODL Client
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i
+ * 			Innovació a Catalunya
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import java.util.Map;
 
 import javax.xml.bind.annotation.XmlAccessType;

--- a/extensions/odl/client/src/main/java/org/mqnaas/extensions/odl/client/switchnorthbound/api/Nodes.java
+++ b/extensions/odl/client/src/main/java/org/mqnaas/extensions/odl/client/switchnorthbound/api/Nodes.java
@@ -1,5 +1,26 @@
 package org.mqnaas.extensions.odl.client.switchnorthbound.api;
 
+/*
+ * #%L
+ * MQNaaS :: ODL Client
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i
+ * 			Innovació a Catalunya
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import java.util.List;
 
 import javax.xml.bind.annotation.XmlAccessType;

--- a/extensions/odl/client/src/main/java/org/mqnaas/extensions/odl/client/switchnorthbound/api/PropertyValue.java
+++ b/extensions/odl/client/src/main/java/org/mqnaas/extensions/odl/client/switchnorthbound/api/PropertyValue.java
@@ -1,5 +1,26 @@
 package org.mqnaas.extensions.odl.client.switchnorthbound.api;
 
+/*
+ * #%L
+ * MQNaaS :: ODL Client
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i
+ * 			Innovació a Catalunya
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;

--- a/extensions/odl/client/src/main/java/org/mqnaas/extensions/odl/client/switchnorthbound/api/adapter/PropertiesMapAdapter.java
+++ b/extensions/odl/client/src/main/java/org/mqnaas/extensions/odl/client/switchnorthbound/api/adapter/PropertiesMapAdapter.java
@@ -1,5 +1,26 @@
 package org.mqnaas.extensions.odl.client.switchnorthbound.api.adapter;
 
+/*
+ * #%L
+ * MQNaaS :: ODL Client
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i
+ * 			Innovació a Catalunya
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;

--- a/extensions/odl/client/src/test/java/org/mqnaas/extensions/odl/client/switchnorthbound/NodeConnectorsSerializationTests.java
+++ b/extensions/odl/client/src/test/java/org/mqnaas/extensions/odl/client/switchnorthbound/NodeConnectorsSerializationTests.java
@@ -1,5 +1,26 @@
 package org.mqnaas.extensions.odl.client.switchnorthbound;
 
+/*
+ * #%L
+ * MQNaaS :: ODL Client
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i
+ * 			Innovació a Catalunya
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;

--- a/extensions/odl/client/src/test/java/org/mqnaas/extensions/odl/client/switchnorthbound/NodesSerializationTests.java
+++ b/extensions/odl/client/src/test/java/org/mqnaas/extensions/odl/client/switchnorthbound/NodesSerializationTests.java
@@ -1,5 +1,26 @@
 package org.mqnaas.extensions.odl.client.switchnorthbound;
 
+/*
+ * #%L
+ * MQNaaS :: ODL Client
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i
+ * 			Innovació a Catalunya
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;

--- a/extensions/odl/client/src/test/java/org/mqnaas/extensions/odl/client/switchnorthbound/SwitchNorthboundAPITests.java
+++ b/extensions/odl/client/src/test/java/org/mqnaas/extensions/odl/client/switchnorthbound/SwitchNorthboundAPITests.java
@@ -1,5 +1,26 @@
 package org.mqnaas.extensions.odl.client.switchnorthbound;
 
+/*
+ * #%L
+ * MQNaaS :: ODL Client
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i
+ * 			Innovació a Catalunya
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import java.io.IOException;
 
 import javax.ws.rs.core.MediaType;

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -18,6 +18,14 @@
 		<module>odl</module>
 	</modules>
 
+	<licenses>
+		<license>
+			<name>Apache License, Version 2.0</name>
+			<url>http://www.apache.org/licenses/LICENSE-2.0</url>
+			<distribution>repo</distribution>
+		</license>
+	</licenses>
+
 	<properties>
 		<!-- UTF-8 encoding -->
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -70,6 +78,15 @@
 
 		<!-- SLF4J version -->
 		<slf4j-version>1.7.7</slf4j-version>
+
+		<!-- Maven license plugin version -->
+		<license.plugin.version>1.8</license.plugin.version>
+
+		<!-- Properties for license -->
+		<project.inceptionYear>2007</project.inceptionYear>
+		<project.organization.name>Fundació Privada i2CAT, Internet i
+			Innovació a Catalunya</project.organization.name>
+		<project.name>OpenNaaS</project.name>
 	</properties>
 
 	<dependencyManagement>
@@ -186,6 +203,33 @@
 	</dependencyManagement>
 
 	<build>
+		<plugins>
+			<!-- License plugin configured below -->
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>license-maven-plugin</artifactId>
+				<configuration>
+					<verbose>false</verbose>
+				</configuration>
+				<executions>
+					<execution>
+						<id>extensions-license</id>
+						<goals>
+							<goal>update-file-header</goal>
+						</goals>
+						<phase>compile</phase>
+						<configuration>
+							<licenseName>apache_v2</licenseName>
+							<roots>
+								<root>src/main/java</root>
+								<root>src/test/java</root>
+							</roots>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+
 		<pluginManagement>
 			<plugins>
 				<!-- Maven bundle plugin allowing the creation of OSGI bundles -->
@@ -262,6 +306,13 @@
 						<source>1.6</source>
 						<target>1.6</target>
 					</configuration>
+				</plugin>
+
+				<!-- License plugin -->
+				<plugin>
+					<groupId>org.codehaus.mojo</groupId>
+					<artifactId>license-maven-plugin</artifactId>
+					<version>${license.plugin.version}</version>
 				</plugin>
 			</plugins>
 		</pluginManagement>

--- a/mqnaas-test-helpers/src/main/java/org/mqnaas/test/helpers/capability/ArtificialBundleGuard.java
+++ b/mqnaas-test-helpers/src/main/java/org/mqnaas/test/helpers/capability/ArtificialBundleGuard.java
@@ -1,5 +1,27 @@
 package org.mqnaas.test.helpers.capability;
 
+/*
+ * #%L
+ * MQNaaS :: MQNaaS Test Helpers
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.mqnaas.bundletree.IBundleGuard;
 import org.mqnaas.bundletree.IClassFilter;
 import org.mqnaas.bundletree.IClassListener;

--- a/mqnaas-test-helpers/src/main/java/org/mqnaas/test/helpers/capability/ArtificialCoreModelCapability.java
+++ b/mqnaas-test-helpers/src/main/java/org/mqnaas/test/helpers/capability/ArtificialCoreModelCapability.java
@@ -1,5 +1,27 @@
 package org.mqnaas.test.helpers.capability;
 
+/*
+ * #%L
+ * MQNaaS :: MQNaaS Test Helpers
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.mqnaas.core.api.ICoreModelCapability;
 import org.mqnaas.core.api.IResource;
 import org.mqnaas.core.api.IRootResource;

--- a/mqnaas-test-helpers/src/main/java/org/mqnaas/test/helpers/capability/TestCapabilitiesFactory.java
+++ b/mqnaas-test-helpers/src/main/java/org/mqnaas/test/helpers/capability/TestCapabilitiesFactory.java
@@ -1,5 +1,27 @@
 package org.mqnaas.test.helpers.capability;
 
+/*
+ * #%L
+ * MQNaaS :: MQNaaS Test Helpers
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.mqnaas.core.api.ICapability;
 import org.mqnaas.core.api.ICoreModelCapability;
 import org.mqnaas.core.api.IRootResource;

--- a/mqnaas-test-helpers/src/main/java/org/mqnaas/test/helpers/clientprovider/EmptyClient.java
+++ b/mqnaas-test-helpers/src/main/java/org/mqnaas/test/helpers/clientprovider/EmptyClient.java
@@ -1,5 +1,27 @@
 package org.mqnaas.test.helpers.clientprovider;
 
+/*
+ * #%L
+ * MQNaaS :: MQNaaS Test Helpers
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.mqnaas.core.api.credentials.Credentials;
 
 /**

--- a/mqnaas-test-helpers/src/main/java/org/mqnaas/test/helpers/clientprovider/EmptyClientAPI.java
+++ b/mqnaas-test-helpers/src/main/java/org/mqnaas/test/helpers/clientprovider/EmptyClientAPI.java
@@ -1,5 +1,27 @@
 package org.mqnaas.test.helpers.clientprovider;
 
+/*
+ * #%L
+ * MQNaaS :: MQNaaS Test Helpers
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 /**
  * Empty client API to be used for test purposes.
  * 

--- a/mqnaas-test-helpers/src/main/java/org/mqnaas/test/helpers/clientprovider/EmptyClientConfiguration.java
+++ b/mqnaas-test-helpers/src/main/java/org/mqnaas/test/helpers/clientprovider/EmptyClientConfiguration.java
@@ -1,5 +1,27 @@
 package org.mqnaas.test.helpers.clientprovider;
 
+/*
+ * #%L
+ * MQNaaS :: MQNaaS Test Helpers
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 /**
  * Empty client configuration to be used for test purposes.
  * 

--- a/mqnaas-test-helpers/src/main/java/org/mqnaas/test/helpers/clientprovider/ProviderFactoryHelpers.java
+++ b/mqnaas-test-helpers/src/main/java/org/mqnaas/test/helpers/clientprovider/ProviderFactoryHelpers.java
@@ -1,5 +1,27 @@
 package org.mqnaas.test.helpers.clientprovider;
 
+/*
+ * #%L
+ * MQNaaS :: MQNaaS Test Helpers
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.lang.reflect.Field;
 
 import org.mqnaas.bundletree.IClassListener;

--- a/mqnaas-test-helpers/src/main/java/org/mqnaas/test/helpers/clientprovider/TestAPIProvider.java
+++ b/mqnaas-test-helpers/src/main/java/org/mqnaas/test/helpers/clientprovider/TestAPIProvider.java
@@ -1,5 +1,27 @@
 package org.mqnaas.test.helpers.clientprovider;
 
+/*
+ * #%L
+ * MQNaaS :: MQNaaS Test Helpers
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.mqnaas.clientprovider.api.apiclient.IAPIClientProvider;
 
 /**

--- a/mqnaas-test-helpers/src/main/java/org/mqnaas/test/helpers/clientprovider/TestClientProvider.java
+++ b/mqnaas-test-helpers/src/main/java/org/mqnaas/test/helpers/clientprovider/TestClientProvider.java
@@ -1,5 +1,27 @@
 package org.mqnaas.test.helpers.clientprovider;
 
+/*
+ * #%L
+ * MQNaaS :: MQNaaS Test Helpers
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.mqnaas.clientprovider.api.client.IClientProvider;
 import org.mqnaas.core.api.IResource;
 

--- a/mqnaas-test-helpers/src/main/java/org/mqnaas/test/helpers/clientprovider/TestClientProviderFactory.java
+++ b/mqnaas-test-helpers/src/main/java/org/mqnaas/test/helpers/clientprovider/TestClientProviderFactory.java
@@ -1,5 +1,27 @@
 package org.mqnaas.test.helpers.clientprovider;
 
+/*
+ * #%L
+ * MQNaaS :: MQNaaS Test Helpers
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 /**
  * Factory providing test implementations of clients, client configurations and providers.
  * 

--- a/mqnaas-test-helpers/src/main/java/org/mqnaas/test/helpers/clientprovider/TestInternalAPIProvider.java
+++ b/mqnaas-test-helpers/src/main/java/org/mqnaas/test/helpers/clientprovider/TestInternalAPIProvider.java
@@ -1,5 +1,27 @@
 package org.mqnaas.test.helpers.clientprovider;
 
+/*
+ * #%L
+ * MQNaaS :: MQNaaS Test Helpers
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.mqnaas.clientprovider.api.apiclient.IInternalAPIClientProvider;
 import org.mqnaas.core.api.Endpoint;
 import org.mqnaas.core.api.credentials.Credentials;

--- a/mqnaas-test-helpers/src/main/java/org/mqnaas/test/helpers/clientprovider/TestInternalClientProvider.java
+++ b/mqnaas-test-helpers/src/main/java/org/mqnaas/test/helpers/clientprovider/TestInternalClientProvider.java
@@ -1,5 +1,27 @@
 package org.mqnaas.test.helpers.clientprovider;
 
+/*
+ * #%L
+ * MQNaaS :: MQNaaS Test Helpers
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.mqnaas.clientprovider.api.client.IInternalClientProvider;
 import org.mqnaas.core.api.Endpoint;
 import org.mqnaas.core.api.credentials.Credentials;

--- a/mqnaas-test-helpers/src/main/java/org/mqnaas/test/helpers/resource/TestResourceFactory.java
+++ b/mqnaas-test-helpers/src/main/java/org/mqnaas/test/helpers/resource/TestResourceFactory.java
@@ -1,5 +1,27 @@
 package org.mqnaas.test.helpers.resource;
 
+/*
+ * #%L
+ * MQNaaS :: MQNaaS Test Helpers
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Arrays;

--- a/pom.xml
+++ b/pom.xml
@@ -88,12 +88,21 @@
 
 		<!-- OSGified javax.inject version -->
 		<javax.inject-version>1_2</javax.inject-version>
-		
+
 		<!-- XMLUnit version -->
 		<xmlunit.version>1.5</xmlunit.version>
 
 		<!-- ASM version -->
 		<asm-version>3.3.1_1</asm-version>
+
+		<!-- Maven license plugin version -->
+		<license.plugin.version>1.8</license.plugin.version>
+
+		<!-- Properties for license -->
+		<project.inceptionYear>2007</project.inceptionYear>
+		<project.organization.name>Fundació Privada i2CAT, Internet i
+			Innovació a Catalunya</project.organization.name>
+		<project.name>OpenNaaS</project.name>
 	</properties>
 
 	<dependencyManagement>
@@ -196,7 +205,7 @@
 				<artifactId>xmlunit</artifactId>
 				<version>${xmlunit.version}</version>
 				<scope>test</scope>
-			</dependency>			
+			</dependency>
 			<dependency>
 				<groupId>commons-io</groupId>
 				<artifactId>commons-io</artifactId>
@@ -252,7 +261,7 @@
 				<artifactId>test-helpers</artifactId>
 				<version>${project.version}</version>
 				<scope>test</scope>
-			</dependency>			
+			</dependency>
 			<dependency>
 				<groupId>org.powermock</groupId>
 				<artifactId>powermock-api-mockito</artifactId>
@@ -264,7 +273,7 @@
 				<artifactId>powermock-module-junit4</artifactId>
 				<version>${powermock.version}</version>
 				<scope>test</scope>
-			</dependency>			
+			</dependency>
 
 			<!-- Runtime dependencies -->
 			<dependency>
@@ -299,6 +308,31 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>build-helper-maven-plugin</artifactId>
+			</plugin>
+
+			<!-- License plugin configured below -->
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>license-maven-plugin</artifactId>
+				<configuration>
+					<verbose>false</verbose>
+				</configuration>
+				<executions>
+					<execution>
+						<id>core-license</id>
+						<goals>
+							<goal>update-file-header</goal>
+						</goals>
+						<phase>compile</phase>
+						<configuration>
+							<licenseName>lgpl_v3</licenseName>
+							<roots>
+								<root>src/main/java</root>
+								<root>src/test/java</root>
+							</roots>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 		</plugins>
 
@@ -372,6 +406,13 @@
 							<Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
 						</instructions>
 					</configuration>
+				</plugin>
+
+				<!-- License plugin -->
+				<plugin>
+					<groupId>org.codehaus.mojo</groupId>
+					<artifactId>license-maven-plugin</artifactId>
+					<version>${license.plugin.version}</version>
 				</plugin>
 			</plugins>
 		</pluginManagement>

--- a/test-helpers/src/main/java/org/mqnaas/general/test/helpers/reflection/ReflectionTestHelper.java
+++ b/test-helpers/src/main/java/org/mqnaas/general/test/helpers/reflection/ReflectionTestHelper.java
@@ -1,5 +1,27 @@
 package org.mqnaas.general.test.helpers.reflection;
 
+/*
+ * #%L
+ * MQNaaS :: General Test Helpers
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.lang.reflect.Field;
 import java.util.List;
 

--- a/test-helpers/src/main/java/org/mqnaas/general/test/helpers/serialization/SerializationUtils.java
+++ b/test-helpers/src/main/java/org/mqnaas/general/test/helpers/serialization/SerializationUtils.java
@@ -1,5 +1,27 @@
 package org.mqnaas.general.test.helpers.serialization;
 
+/*
+ * #%L
+ * MQNaaS :: General Test Helpers
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import java.io.InputStream;
 import java.io.StringReader;
 import java.io.StringWriter;

--- a/test-helpers/src/test/java/org/mqnaas/general/test/helpers/ReflectionTestHelperTests.java
+++ b/test-helpers/src/test/java/org/mqnaas/general/test/helpers/ReflectionTestHelperTests.java
@@ -1,5 +1,27 @@
 package org.mqnaas.general.test.helpers;
 
+/*
+ * #%L
+ * MQNaaS :: General Test Helpers
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 import org.junit.Assert;
 import org.junit.Test;
 import org.mqnaas.general.test.helpers.reflection.ReflectionTestHelper; 

--- a/test-helpers/src/test/java/org/mqnaas/general/test/helpers/TestClass.java
+++ b/test-helpers/src/test/java/org/mqnaas/general/test/helpers/TestClass.java
@@ -1,5 +1,27 @@
 package org.mqnaas.general.test.helpers;
 
+/*
+ * #%L
+ * MQNaaS :: General Test Helpers
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 /**
  * Class for testing purposes
  * 


### PR DESCRIPTION
Add Maven license plugin configuration in order to generate automatic source code headers including license information. Use [GNU Lesser General Public License version 3 (LGPLv3)](https://www.gnu.org/licenses/lgpl.html) for core and [Apache License version 2.0 (ALv2)](http://www.apache.org/licenses/LICENSE-2.0) for extensions.