### PR TITLE
Feature/flowmanager odl add and remove

### DIFF
--- a/extensions/modelreader/modelreader-capability/src/main/java/org/mqnaas/extensions/modelreader/impl/ResourceModelReader.java
+++ b/extensions/modelreader/modelreader-capability/src/main/java/org/mqnaas/extensions/modelreader/impl/ResourceModelReader.java
@@ -103,7 +103,7 @@ public class ResourceModelReader implements IResourceModelReader {
 				// FIXME this should be generalized.
 				else if (capabilityClass.equals(IFlowManagement.class)) {
 					IFlowManagement flowMgmCapab = serviceProvider.getCapability(resource, IFlowManagement.class);
-					modelWrapper.setConfiguredRules(flowMgmCapab.getFlows());
+					modelWrapper.setConfiguredRules(flowMgmCapab.getAllFlows());
 				}
 				else {
 

--- a/extensions/odl/capabilities/src/main/java/org/mqnaas/extensions/odl/capabilities/flows/IFlowManagement.java
+++ b/extensions/odl/capabilities/src/main/java/org/mqnaas/extensions/odl/capabilities/flows/IFlowManagement.java
@@ -77,9 +77,11 @@ public interface IFlowManagement extends ICapability {
 	 * 
 	 * @param flowName
 	 * @throws NotFoundException when given flowName is unknown
+	 * @throws IllegalStateException
+	 * @throws Exception if there is any error while deleting the flow
 	 */
 	@Path("/{flow}")
 	@DELETE
-	public void deleteFlow(@PathParam("dpid") String dpid, @PathParam("flow") String flowName) throws NotFoundException;
+	public void deleteFlow(@PathParam("dpid") String dpid, @PathParam("flow") String flowName) throws NotFoundException, IllegalStateException, Exception;
 	
 }

--- a/extensions/odl/capabilities/src/main/java/org/mqnaas/extensions/odl/capabilities/flows/IFlowManagement.java
+++ b/extensions/odl/capabilities/src/main/java/org/mqnaas/extensions/odl/capabilities/flows/IFlowManagement.java
@@ -47,7 +47,7 @@ public interface IFlowManagement extends ICapability {
 	 */
 	@GET
 	@Produces(MediaType.APPLICATION_XML)
-	public FlowConfigs getFlows() throws Exception;
+	public FlowConfigs getAllFlows() throws Exception;
 	
 	/**
 	 * 

--- a/extensions/odl/capabilities/src/main/java/org/mqnaas/extensions/odl/capabilities/flows/IFlowManagement.java
+++ b/extensions/odl/capabilities/src/main/java/org/mqnaas/extensions/odl/capabilities/flows/IFlowManagement.java
@@ -27,7 +27,6 @@ import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.NotFoundException;
 import javax.ws.rs.POST;
-import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
@@ -67,10 +66,12 @@ public interface IFlowManagement extends ICapability {
 	 * 
 	 * @param flow
 	 * @throws BadRequestException when flow is already configured
+	 * @throws IllegalStateException 
+	 * @throws Exception if there is any error while configuring the flow
 	 */
 	@POST
 	@Consumes(MediaType.APPLICATION_XML)
-	public void addFlow(FlowConfig flow) throws BadRequestException;
+	public void addFlow(FlowConfig flow) throws BadRequestException, IllegalStateException, Exception;
 	
 	/**
 	 * 
@@ -79,16 +80,6 @@ public interface IFlowManagement extends ICapability {
 	 */
 	@Path("/{flow}")
 	@DELETE
-	public void deleteFlow(@PathParam("flow") String flowName) throws NotFoundException;
+	public void deleteFlow(@PathParam("dpid") String dpid, @PathParam("flow") String flowName) throws NotFoundException;
 	
-	/**
-	 * 
-	 * @param flowName
-	 * @param updated
-	 * @throws NotFoundException when given flowName is unknown
-	 */
-	@Path("/{flow}")
-	@PUT
-	@Consumes(MediaType.APPLICATION_XML)
-	public void updateFlow(@PathParam("flow") String flowName, FlowConfig updated) throws NotFoundException;
 }

--- a/extensions/odl/capabilities/src/main/java/org/mqnaas/extensions/odl/capabilities/flows/ODLFlowManagement.java
+++ b/extensions/odl/capabilities/src/main/java/org/mqnaas/extensions/odl/capabilities/flows/ODLFlowManagement.java
@@ -65,7 +65,7 @@ public class ODLFlowManagement implements IFlowManagement {
 	}
 
 	@Override
-	public FlowConfigs getFlows() throws IllegalStateException, Exception {
+	public FlowConfigs getAllFlows() throws IllegalStateException, Exception {
 		return getFlowProgrammerClient().getStaticFlows();
 	}
 

--- a/extensions/odl/capabilities/src/main/java/org/mqnaas/extensions/odl/capabilities/flows/ODLFlowManagement.java
+++ b/extensions/odl/capabilities/src/main/java/org/mqnaas/extensions/odl/capabilities/flows/ODLFlowManagement.java
@@ -78,17 +78,12 @@ public class ODLFlowManagement implements IFlowManagement {
 	}
 	
 	@Override
-	public void addFlow(FlowConfig flow) throws BadRequestException {
+	public void addFlow(FlowConfig flow) throws IllegalStateException, Exception {
 		throw new UnsupportedOperationException("Not implemented");
 	}
 
 	@Override
-	public void deleteFlow(String flowName) throws NotFoundException {
-		throw new UnsupportedOperationException("Not implemented");
-	}
-
-	@Override
-	public void updateFlow(String flowName, FlowConfig updated) throws NotFoundException {
+	public void deleteFlow(String dpid, String flowName) throws NotFoundException {
 		throw new UnsupportedOperationException("Not implemented");
 	}
 	

--- a/extensions/odl/capabilities/src/main/java/org/mqnaas/extensions/odl/capabilities/flows/ODLFlowManagement.java
+++ b/extensions/odl/capabilities/src/main/java/org/mqnaas/extensions/odl/capabilities/flows/ODLFlowManagement.java
@@ -21,9 +21,6 @@ package org.mqnaas.extensions.odl.capabilities.flows;
  * #L%
  */
 
-import javax.ws.rs.BadRequestException;
-import javax.ws.rs.NotFoundException;
-
 import org.apache.commons.lang3.StringUtils;
 import org.mqnaas.client.cxf.ICXFAPIProvider;
 import org.mqnaas.clientprovider.api.apiclient.IAPIClientProviderFactory;
@@ -79,12 +76,12 @@ public class ODLFlowManagement implements IFlowManagement {
 	
 	@Override
 	public void addFlow(FlowConfig flow) throws IllegalStateException, Exception {
-		throw new UnsupportedOperationException("Not implemented");
+		getFlowProgrammerClient().addOrModifyFlow(flow, flow.getNode().getId(), flow.getName());
 	}
 
 	@Override
-	public void deleteFlow(String dpid, String flowName) throws NotFoundException {
-		throw new UnsupportedOperationException("Not implemented");
+	public void deleteFlow(String dpid, String flowName) throws IllegalStateException, Exception {
+		getFlowProgrammerClient().deleteFlow(dpid, flowName);
 	}
 	
 	/**


### PR DESCRIPTION
This patch implements IFlowManagement addFlow and removelow methods in ODLFlowManagement.
How to access the new functionality is explained in http://jira.i2cat.net/browse/OPENNAAS-1596

ODLFlowManagement now implements IFlowManagement complete interface.

Fixes issues:
http://jira.i2cat.net/browse/OPENNAAS-1598
http://jira.i2cat.net/browse/OPENNAAS-1599

It also modifies the way to retrieve all flows. 
So it affects issue: http://jira.i2cat.net/browse/OPENNAAS-1567