### PR TITLE
Feature/odl network autoloads links

### DIFF
--- a/extensions/odl/capabilities/src/main/java/org/mqnaas/extensions/odl/capabilities/impl/ODLRootResourceProvider.java
+++ b/extensions/odl/capabilities/src/main/java/org/mqnaas/extensions/odl/capabilities/impl/ODLRootResourceProvider.java
@@ -95,7 +95,7 @@ public class ODLRootResourceProvider implements IRootResourceProvider {
 
 	private List<IRootResource>		resources;
 
-	private ISwitchNorthboundAPI	odlClient;
+	private ISwitchNorthboundAPI	odlSwitchManagerClient;
 
 	public static boolean isSupporting(IRootResource resource) {
 		Specification specification = resource.getDescriptor().getSpecification();
@@ -108,7 +108,7 @@ public class ODLRootResourceProvider implements IRootResourceProvider {
 		log.info("Initializing ODLRootResourceProvider for resource " + resource.getId());
 
 		try {
-			odlClient = apiProviderFactory.getAPIProvider(ICXFAPIProvider.class).getAPIClient(resource, ISwitchNorthboundAPI.class);
+			odlSwitchManagerClient = apiProviderFactory.getAPIProvider(ICXFAPIProvider.class).getAPIClient(resource, ISwitchNorthboundAPI.class);
 		} catch (EndpointNotFoundException e) {
 			log.error("Error activating ODLRootResourceProvider capability: Endpoint could not be found", e);
 			throw new ApplicationActivationException(e);
@@ -190,7 +190,7 @@ public class ODLRootResourceProvider implements IRootResourceProvider {
 
 		resources = new CopyOnWriteArrayList<IRootResource>();
 
-		Nodes nodes = odlClient.getNodes(DEFAULT_CONNECTOR_NAME);
+		Nodes nodes = odlSwitchManagerClient.getNodes(DEFAULT_CONNECTOR_NAME);
 
 		for (NodeProperties nodeProperties : nodes.getNodeProperties()) {
 			// get information from the node
@@ -204,7 +204,7 @@ public class ODLRootResourceProvider implements IRootResourceProvider {
 
 			// create ports
 			IPortManagement portMgm = serviceProvider.getCapability(odlResource, IPortManagement.class);
-			NodeConnectors nodePorts = odlClient.getNodeConnectors(DEFAULT_CONNECTOR_NAME, nodeProperties.getNode().getNodeType().toString(), nodeId);
+			NodeConnectors nodePorts = odlSwitchManagerClient.getNodeConnectors(DEFAULT_CONNECTOR_NAME, nodeProperties.getNode().getNodeType().toString(), nodeId);
 			for (NodeConnectorProperties nodePortProperties : nodePorts.getNodeConnectorProperties()) {
 				String nodePortId = nodePortProperties.getNodeConnector().getNodeConnectorID();
 				String nodePortName = nodePortProperties.getProperties().get("name").getValue();

--- a/extensions/odl/model/src/main/java/org/mqnaas/extensions/odl/hellium/topology/model/Topology.java
+++ b/extensions/odl/model/src/main/java/org/mqnaas/extensions/odl/hellium/topology/model/Topology.java
@@ -36,7 +36,7 @@ import javax.xml.bind.annotation.XmlRootElement;
  * @author Adrián Roselló Rey (i2CAT)
  *
  */
-@XmlRootElement(namespace = "org.mqnaas")
+@XmlRootElement
 @XmlAccessorType(XmlAccessType.FIELD)
 public class Topology {
 

--- a/extensions/odl/model/src/test/resources/serialization/test-topology.xml
+++ b/extensions/odl/model/src/test/resources/serialization/test-topology.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<ns2:topology xmlns:ns2="org.mqnaas">
+<topology>
     <edgeProperties>
         <edge>
             <tailNodeConnector>
@@ -86,4 +86,4 @@
             </property>
         </properties>
     </edgeProperties>
-</ns2:topology>
+</topology>


### PR DESCRIPTION
ODLRootResourceProvider loads links when activated.

Link information is gathered from ODL using IOpenDaylightTopologyNorthbound client
and stored in the network using ILinkManagement capability.

Fixes issue http://jira.i2cat.net/browse/OPENNAAS-1602