### PR TITLE
Avoid NullPointerException when resources have null model or version.

### DIFF
--- a/core.api/src/main/java/org/mqnaas/core/api/IRootResourceProvider.java
+++ b/core.api/src/main/java/org/mqnaas/core/api/IRootResourceProvider.java
@@ -54,6 +54,10 @@ public interface IRootResourceProvider extends ICapability {
 	/**
 	 * Returns the subset of {@link IRootResource}s managed by this capability matching a specific {@link Specification.Type}, model and version.
 	 * 
+	 * Unspecified model (=null) matches all models. <br>
+	 * Unspecified version (=null) matches all versions. <br>
+	 * Specified fields (type, model and version !=null) match only the same value.
+	 * 
 	 * @param type
 	 *            Resource type.
 	 * @param model

--- a/core/src/main/java/org/mqnaas/core/impl/RootResourceManagement.java
+++ b/core/src/main/java/org/mqnaas/core/impl/RootResourceManagement.java
@@ -97,10 +97,13 @@ public class RootResourceManagement implements IRootResourceProvider, IRootResou
 
 			Specification specification = resource.getDescriptor().getSpecification();
 
+			// Unspecified model (=null) matches all models
+			// Unspecified version (=null) matches all versions
+			// Specified fields (type, model and version !=null) match only the same value
 			boolean matches = true;
-			matches &= type != null ? specification.getType().equals(type) : true;
-			matches &= model != null ? specification.getModel().equals(model) : true;
-			matches &= version != null ? specification.getVersion().equals(version) : true;
+			matches &= (type != null) ? specification.getType().equals(type) : true;
+			matches &= (model != null) ? StringUtils.equals(specification.getModel(), model) : true;
+			matches &= (version != null) ? StringUtils.equals(specification.getVersion(), version) : true;
 
 			if (matches)
 				filteredResources.add(resource);

--- a/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/NetworkRootResourceProvider.java
+++ b/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/NetworkRootResourceProvider.java
@@ -82,10 +82,13 @@ public class NetworkRootResourceProvider implements IRootResourceProvider {
 
 			Specification specification = resource.getDescriptor().getSpecification();
 
+			// Unspecified model (=null) matches all models
+			// Unspecified version (=null) matches all versions
+			// Specified fields (type, model and version !=null) match only the same value
 			boolean matches = true;
-			matches &= (type != null && specification.getType() != null) ? specification.getType().equals(type) : true;
-			matches &= (model != null && specification.getModel() != null) ? specification.getModel().equals(model) : true;
-			matches &= (version != null && specification.getVersion() != null) ? specification.getVersion().equals(version) : true;
+			matches &= (type != null) ? specification.getType().equals(type) : true;
+			matches &= (model != null) ? StringUtils.equals(specification.getModel(), model) : true;
+			matches &= (version != null) ? StringUtils.equals(specification.getVersion(), version) : true;
 
 			if (matches)
 				filteredResources.add(resource);

--- a/extensions/odl/capabilities/src/main/java/org/mqnaas/extensions/odl/capabilities/impl/ODLRootResourceProvider.java
+++ b/extensions/odl/capabilities/src/main/java/org/mqnaas/extensions/odl/capabilities/impl/ODLRootResourceProvider.java
@@ -166,10 +166,13 @@ public class ODLRootResourceProvider implements IRootResourceProvider {
 
 			Specification specification = resource.getDescriptor().getSpecification();
 
+			// Unspecified model (=null) matches all models
+			// Unspecified version (=null) matches all versions
+			// Specified fields (type, model and version !=null) match only the same value
 			boolean matches = true;
-			matches &= type != null ? specification.getType().equals(type) : true;
-			matches &= model != null ? specification.getModel().equals(model) : true;
-			matches &= version != null ? specification.getVersion().equals(version) : true;
+			matches &= (type != null) ? specification.getType().equals(type) : true;
+			matches &= (model != null) ? StringUtils.equals(specification.getModel(), model) : true;
+			matches &= (version != null) ? StringUtils.equals(specification.getVersion(), version) : true;
 
 			if (matches)
 				filteredResources.add(resource);


### PR DESCRIPTION
This patch additionally unequivocally defines the matching process for getRootResources(type, model, version),
and modifies implementation to tie to the process.