### PR TITLE
Move Period overlap logic.

### DIFF
--- a/extensions/network/network.api/src/main/java/org/mqnaas/network/api/request/Period.java
+++ b/extensions/network/network.api/src/main/java/org/mqnaas/network/api/request/Period.java
@@ -73,6 +73,26 @@ public class Period implements Comparable<Period> {
 	}
 
 	/**
+	 * Checks if this period overlaps with other.
+	 * 
+	 * @param other
+	 *            Period to be checked with this.
+	 * @return <code>true</code> if both periods overlap. <code>false</code> otherwise.
+	 */
+	public boolean overlap(Period other) {
+		if (this.getEndDate().after(other.getStartdate()) && this.getEndDate().before(other.getEndDate()))
+			return true;
+		if (this.getStartdate().after(other.getStartdate()) && this.getStartdate().before(other.getEndDate()))
+			return true;
+
+		if (this.getStartdate().before(other.getStartdate()) && this.getEndDate().after(other.getEndDate()))
+			return true;
+
+		return (this.getStartdate().equals(other.getStartdate()) || this.getEndDate().equals(other.getEndDate()) || this.getStartdate()
+				.equals(other.getEndDate()) || this.getEndDate().equals(other.getStartdate()));
+	}
+
+	/**
 	 * @return <ul>
 	 *         <li>"-1", if the starting and end date are smaller than the starting date of the <code>other</code> period.</li>
 	 *         <li>"1", if the starting and end date are smaller than the end date of the <code>other</code>period.</li>

--- a/extensions/network/network.api/src/test/java/org/mqnaas/network/api/PeriodOverlapTests.java
+++ b/extensions/network/network.api/src/test/java/org/mqnaas/network/api/PeriodOverlapTests.java
@@ -1,0 +1,67 @@
+package org.mqnaas.network.api;
+
+import java.util.Date;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.mqnaas.network.api.request.Period;
+
+/**
+ * {@link Period} tests regarding overlaps
+ * 
+ * @author Julio Carlos Barrera
+ * @author Adrián Roselló Rey (i2CAT)
+ *
+ */
+public class PeriodOverlapTests {
+
+	/**
+	 * Test checks the {@link Period#overlap(Period)} method with different Period combinations.
+	 */
+	@Test
+	public void periodsOverlapTest() {
+
+		long currentTime = System.currentTimeMillis();
+
+		// startDate2 < endDate2 < starDate1 < endDate1 -> FALSE
+		Period period1 = new Period(new Date(currentTime), new Date(currentTime + 5000L));
+		Period period2 = new Period(new Date(currentTime - 6000L), new Date(currentTime - 5000L));
+		Assert.assertFalse(period1.overlap(period2));
+
+		// startDate1 < endDate1 < starDate2 < endDate2 -> FALSE
+		period1 = new Period(new Date(currentTime), new Date(currentTime + 5000L));
+		period2 = new Period(new Date(currentTime + 10000L), new Date(currentTime + 15000L));
+		Assert.assertFalse(period1.overlap(period2));
+
+		// strartDate2 < startDate1 < endDate1 < endDate2 -> TRUE
+		period1 = new Period(new Date(currentTime), new Date(currentTime + 15000L));
+		period2 = new Period(new Date(currentTime + 5000L), new Date(currentTime + 10000L));
+		Assert.assertTrue(period1.overlap(period2));
+
+		// strartDate2 < startDate1 < endDate2 < endDate1 -> TRUE
+		period1 = new Period(new Date(currentTime), new Date(currentTime + 10000L));
+		period2 = new Period(new Date(currentTime + 5000L), new Date(currentTime + 15000L));
+		Assert.assertTrue(period1.overlap(period2));
+
+		// strartDate1 < startDate2 < endDate1 < endDate2 -> TRUE
+		period1 = new Period(new Date(currentTime + 5000L), new Date(currentTime + 15000L));
+		period2 = new Period(new Date(currentTime), new Date(currentTime + 10000L));
+		Assert.assertTrue(period1.overlap(period2));
+
+		// startDate1 = startDate2
+		period1 = new Period(new Date(currentTime), new Date(currentTime + 15000L));
+		period2 = new Period(new Date(currentTime), new Date(currentTime + 10000L));
+		Assert.assertTrue(period1.overlap(period2));
+
+		// endDate1 = endDate2
+		period1 = new Period(new Date(currentTime + 5000), new Date(currentTime + 10000L));
+		period2 = new Period(new Date(currentTime), new Date(currentTime + 10000L));
+		Assert.assertTrue(period1.overlap(period2));
+
+		// endDateX = startDateY
+		period1 = new Period(new Date(currentTime), new Date(currentTime + 5000L));
+		period2 = new Period(new Date(currentTime + 5000L), new Date(currentTime + 10000L));
+		Assert.assertTrue(period1.overlap(period2));
+
+	}
+}

--- a/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/reservation/ReservationUtils.java
+++ b/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/reservation/ReservationUtils.java
@@ -36,29 +36,6 @@ import org.mqnaas.network.api.reservation.ReservationResource;
 public class ReservationUtils {
 
 	/**
-	 * Checks if both periods overlap or not.
-	 * 
-	 * @param period1
-	 *            First period to be checked.
-	 * @param period2
-	 *            Second period to be checked.
-	 * @return <code>true</code> if both periods overlap. <code>false</code> otherwise.
-	 */
-	public static boolean periodsOverlap(Period period1, Period period2) {
-		if (period1.getEndDate().after(period2.getStartdate()) && period1.getEndDate().before(period2.getEndDate()))
-			return true;
-		if (period1.getStartdate().after(period2.getStartdate()) && period1.getStartdate().before(period2.getEndDate()))
-			return true;
-
-		if (period1.getStartdate().before(period2.getStartdate()) && period1.getEndDate().after(period2.getEndDate()))
-			return true;
-
-		return (period1.getStartdate().equals(period2.getStartdate()) || period1.getEndDate().equals(period2.getEndDate()) || period1.getStartdate()
-				.equals(period2.getEndDate()) || period1.getEndDate().equals(period2.getStartdate()));
-
-	}
-
-	/**
 	 * Checks if any {@link IRootResource} stored in the {@link IReservationAdministration} of a new {@link ReservationResource} are contained in the
 	 * <code>existingReservationAdmin</code> for the same {@link Period}.
 	 * 
@@ -78,7 +55,7 @@ public class ReservationUtils {
 
 		for (IRootResource reservationResource : reservationToCompareAdmin.getResources())
 			if (existingReservationAdmin.getResources().contains(reservationResource))
-				if (periodsOverlap(existingReservationAdmin.getPeriod(), reservationToCompareAdmin.getPeriod()))
+				if (existingReservationAdmin.getPeriod().overlap(reservationToCompareAdmin.getPeriod()))
 					return false;
 
 		return true;

--- a/extensions/network/network.impl/src/test/java/org/mqnaas/network/impl/reservation/ReservationUtilsTest.java
+++ b/extensions/network/network.impl/src/test/java/org/mqnaas/network/impl/reservation/ReservationUtilsTest.java
@@ -63,61 +63,6 @@ public class ReservationUtilsTest {
 	}
 
 	/**
-	 * Test checks the {@link ReservationUtils#periodsOverlap(Period, Period)} method with different periods combinations.
-	 */
-	@Test
-	public void periodsOverlapTest() {
-
-		long currentTime = System.currentTimeMillis();
-
-		// startDate2 < endDate2 < starDate1 < endDate1 -> FALSE
-
-		Period period1 = new Period(new Date(currentTime), new Date(currentTime + 5000L));
-		Period period2 = new Period(new Date(currentTime - 6000L), new Date(currentTime - 5000L));
-		Assert.assertFalse(ReservationUtils.periodsOverlap(period1, period2));
-
-		// startDate1 < endDate1 < starDate2 < endDate2 -> FALSE
-
-		period1 = new Period(new Date(currentTime), new Date(currentTime + 5000L));
-		period2 = new Period(new Date(currentTime + 10000L), new Date(currentTime + 15000L));
-		Assert.assertFalse(ReservationUtils.periodsOverlap(period1, period2));
-
-		// strartDate2 < startDate1 < endDate1 < endDate2 -> TRUE
-
-		period1 = new Period(new Date(currentTime), new Date(currentTime + 15000L));
-		period2 = new Period(new Date(currentTime + 5000L), new Date(currentTime + 10000L));
-		Assert.assertTrue(ReservationUtils.periodsOverlap(period1, period2));
-
-		// strartDate2 < startDate1 < endDate2 < endDate1 -> TRUE
-
-		period1 = new Period(new Date(currentTime), new Date(currentTime + 10000L));
-		period2 = new Period(new Date(currentTime + 5000L), new Date(currentTime + 15000L));
-		Assert.assertTrue(ReservationUtils.periodsOverlap(period1, period2));
-
-		// strartDate1 < startDate2 < endDate1 < endDate2 -> TRUE
-
-		period1 = new Period(new Date(currentTime + 5000L), new Date(currentTime + 15000L));
-		period2 = new Period(new Date(currentTime), new Date(currentTime + 10000L));
-		Assert.assertTrue(ReservationUtils.periodsOverlap(period1, period2));
-
-		// startDate1 = startDate2
-		period1 = new Period(new Date(currentTime), new Date(currentTime + 15000L));
-		period2 = new Period(new Date(currentTime), new Date(currentTime + 10000L));
-		Assert.assertTrue(ReservationUtils.periodsOverlap(period1, period2));
-
-		// endDate1 = endDate2
-		period1 = new Period(new Date(currentTime + 5000), new Date(currentTime + 10000L));
-		period2 = new Period(new Date(currentTime), new Date(currentTime + 10000L));
-		Assert.assertTrue(ReservationUtils.periodsOverlap(period1, period2));
-
-		// endDateX = startDateY
-		period1 = new Period(new Date(currentTime), new Date(currentTime + 5000L));
-		period2 = new Period(new Date(currentTime + 5000L), new Date(currentTime + 10000L));
-		Assert.assertTrue(ReservationUtils.periodsOverlap(period1, period2));
-
-	}
-
-	/**
 	 * Test checks {@link ReservationUtils#areResourcesAvailable(IReservationAdministration, IReservationAdministration) method with different
 	 * resources-periods combinations.}
 	 */


### PR DESCRIPTION
Moved Period overlap logic from `ReservationUtils` class to `Period` class. Move tests consequently.