### PR TITLE
Improvement/test-for-binding

### DIFF
--- a/core/src/main/java/org/mqnaas/core/impl/BindingManagement.java
+++ b/core/src/main/java/org/mqnaas/core/impl/BindingManagement.java
@@ -438,10 +438,14 @@ public class BindingManagement implements IServiceProvider, IResourceManagementL
 		// Bind matching capabilities
 		for (Class<? extends ICapability> capabilityClass : knownCapabilities) {
 			if (bindingDecider.shouldBeBound(added.getContent(), capabilityClass)) {
-				if (!ResourceCapabilityTreeController.isBound(capabilityClass, added)) {
+				if (!ResourceCapabilityTreeController.isBound(capabilityClass, added)
+						&& ResourceCapabilityTreeController.canBind(capabilityClass, added)) {
 					bindingManagement.bind(new CapabilityNode(new CapabilityInstance(capabilityClass)), added);
 				} else {
-					log.info("Already bound " + capabilityClass + " to resource " + added.getContent());
+					if (ResourceCapabilityTreeController.isBound(capabilityClass, added))
+						log.info("Already bound " + capabilityClass + " to resource " + added.getContent());
+					else
+						log.info("Unable to bind " + capabilityClass + " to resource " + added.getContent());
 				}
 			}
 		}
@@ -756,7 +760,8 @@ public class BindingManagement implements IServiceProvider, IResourceManagementL
 		for (ResourceNode resourceNode : ResourceCapabilityTreeController.getAllResourceNodes(tree.getRootResourceNode())) {
 			for (Class<? extends ICapability> capabilityClass : capabilityClasses) {
 				if (bindingDecider.shouldBeBound(resourceNode.getContent(), capabilityClass)) {
-					if (!ResourceCapabilityTreeController.isBound(capabilityClass, resourceNode))
+					if (!ResourceCapabilityTreeController.isBound(capabilityClass, resourceNode)
+							&& ResourceCapabilityTreeController.canBind(capabilityClass, resourceNode))
 						if (bindingManagement != null) {
 							bindingManagement.bind(new CapabilityNode(new CapabilityInstance(capabilityClass)), resourceNode);
 						} else {

--- a/core/src/main/java/org/mqnaas/core/impl/resourcetree/ResourceCapabilityTreeController.java
+++ b/core/src/main/java/org/mqnaas/core/impl/resourcetree/ResourceCapabilityTreeController.java
@@ -22,6 +22,7 @@ package org.mqnaas.core.impl.resourcetree;
  * #L%
  */
 
+import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -104,8 +105,9 @@ public class ResourceCapabilityTreeController {
 
 	public static boolean isBound(Class<? extends ICapability> capabilityClass, ResourceNode resourceNode) {
 		for (CapabilityNode capabilityNode : resourceNode.getChildren()) {
-			if (capabilityNode.getContent().getClazz().equals(capabilityClass))
-				return true;
+			for (Class<?> capabilityIface : capabilityNode.getContent().getClazz().getInterfaces())
+				if (Arrays.asList(capabilityClass.getInterfaces()).contains(capabilityIface))
+					return true;
 		}
 		return false;
 	}

--- a/core/src/main/java/org/mqnaas/core/impl/resourcetree/ResourceCapabilityTreeController.java
+++ b/core/src/main/java/org/mqnaas/core/impl/resourcetree/ResourceCapabilityTreeController.java
@@ -105,9 +105,24 @@ public class ResourceCapabilityTreeController {
 
 	public static boolean isBound(Class<? extends ICapability> capabilityClass, ResourceNode resourceNode) {
 		for (CapabilityNode capabilityNode : resourceNode.getChildren()) {
-			for (Class<?> capabilityIface : capabilityNode.getContent().getClazz().getInterfaces())
-				if (Arrays.asList(capabilityClass.getInterfaces()).contains(capabilityIface))
+			if (capabilityNode.getContent().getClazz().equals(capabilityClass))
+				return true;
+		}
+		return false;
+	}
+
+	public static boolean canBind(Class<? extends ICapability> capabilityClass, ResourceNode resourceNode) {
+		// To be able to bind, any of the interfaces implemented by capabilityClass MUST NOT be already implemented
+		// by capabilities already bound to the resource.
+		return !doesCapabilityImplementAlreadyProvidedInterfaces(capabilityClass, resourceNode);
+	}
+
+	private static boolean doesCapabilityImplementAlreadyProvidedInterfaces(Class<? extends ICapability> capabilityClass, ResourceNode resourceNode) {
+		for (Class<?> capabilityIface : capabilityClass.getInterfaces()) {
+			for (CapabilityNode capabilityNode : resourceNode.getChildren()) {
+				if (Arrays.asList(capabilityNode.getContent().getClazz().getInterfaces()).contains(capabilityIface))
 					return true;
+			}
 		}
 		return false;
 	}

--- a/core/src/test/java/org/mqnaas/core/impl/BindingManagementTest.java
+++ b/core/src/test/java/org/mqnaas/core/impl/BindingManagementTest.java
@@ -30,6 +30,8 @@ import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.BDDMockito;
+import org.mockito.Mockito;
 import org.mqnaas.core.api.IApplication;
 import org.mqnaas.core.api.IBindingDecider;
 import org.mqnaas.core.api.ICapability;
@@ -57,7 +59,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
  */
 // needed to mock static method of FrameworkUtil class.
 @RunWith(PowerMockRunner.class)
-@PrepareForTest(FrameworkUtil.class)
+@PrepareForTest({ FrameworkUtil.class, SampleCapability.class })
 public class BindingManagementTest {
 
 	static RootResourceManagement	resourceManagement;
@@ -293,6 +295,24 @@ public class BindingManagementTest {
 			Assert.assertTrue("Resource should NOT be provided by capability",
 					bindingManagement.getResourcesProvidedByCapabilityInstance(chainCapabilityInstances.get(i)).isEmpty());
 		}
+
+		removeSampleCapability();
+	}
+
+	@Test
+	public void doNotBindCapabilityToUnsopportedResources() {
+
+		addSampleCapability();
+
+		PowerMockito.mockStatic(SampleCapability.class);
+		BDDMockito.given(SampleCapability.isSupporting(Mockito.any(IResource.class))).willReturn(false);
+
+		IResource core = coreProvider.getCore();
+
+		CapabilityInstance sampleCI = getCapabilityInstanceBoundToResource(core, SampleCapability.class);
+		Assert.assertTrue("BindingManagement should contain SampleCapability in the list of known capabilities.",
+				bindingManagement.knownCapabilities.contains(SampleCapability.class));
+		Assert.assertNull("SampleCapability should not be bound to any resource.", sampleCI);
 
 		removeSampleCapability();
 	}

--- a/core/src/test/java/org/mqnaas/core/impl/BindingManagementTest.java
+++ b/core/src/test/java/org/mqnaas/core/impl/BindingManagementTest.java
@@ -167,6 +167,35 @@ public class BindingManagementTest {
 	}
 
 	@Test
+	public void bindDifferentCapabilityInstancesToDifferentResources() throws CapabilityNotFoundException, ApplicationNotFoundException {
+
+		addSampleCapability();
+
+		IResource core = coreProvider.getCore();
+
+		CapabilityInstance sampleCI = getCapabilityInstanceBoundToResource(core, SampleCapability.class);
+
+		Assert.assertTrue("CI should be bound to the resource",
+				bindingManagement.getCapabilityInstancesBoundToResource(core).contains(sampleCI));
+
+		IResource sampleResource = generateSampleResource();
+		bindingManagement.resourceAdded(sampleResource, sampleCI.getInstance(), ISampleCapability.class);
+
+		CapabilityInstance sampleCIForCoreResource = getCapabilityInstanceBoundToResource(core, SampleCapability.class);
+		CapabilityInstance sampleCIForSampleResource = getCapabilityInstanceBoundToResource(sampleResource, SampleCapability.class);
+
+		Assert.assertNotNull("SampleCapability should be bound to any resource.", sampleCIForCoreResource);
+		Assert.assertNotNull("SampleCapability should be bound to any resource.", sampleCIForSampleResource);
+		Assert.assertFalse("Both resources should contained two different bound capabilities instances of the same type.",
+				sampleCIForCoreResource.getInstance() == sampleCIForSampleResource.getInstance());
+
+		bindingManagement.resourceRemoved(sampleResource, sampleCI.getInstance(), ISampleCapability.class);
+
+		removeSampleCapability();
+
+	}
+
+	@Test
 	public void addAndRemoveResourceInCapabilityInstance() throws ResourceNotFoundException, CapabilityNotFoundException,
 			ApplicationNotFoundException {
 

--- a/core/src/test/java/org/mqnaas/core/impl/BindingManagementTest.java
+++ b/core/src/test/java/org/mqnaas/core/impl/BindingManagementTest.java
@@ -171,6 +171,8 @@ public class BindingManagementTest {
 		IResource core = coreProvider.getCore();
 
 		CapabilityInstance sampleCI = getCapabilityInstanceBoundToResource(core, SampleCapability.class);
+		Assert.assertTrue(bindingManagement.knownCapabilities.contains(SampleCapability.class));
+
 		Assert.assertNotNull(sampleCI);
 
 		IResource sampleResource = generateSampleResource();
@@ -188,10 +190,15 @@ public class BindingManagementTest {
 
 		bindingManagement.resourceRemoved(sampleResource, sampleCI.getInstance(), ISampleCapability.class);
 
-		Assert.assertFalse("SampleResource should NOT provided by SampleCapability",
+		Assert.assertFalse("SampleResource should NOT be provided by SampleCapability",
 				bindingManagement.getResourcesProvidedByCapabilityInstance(sampleCI).contains(sampleResource));
 
 		removeSampleCapability();
+
+		Assert.assertNull("SampleCapability should have been unbound from core resource.",
+				getCapabilityInstanceBoundToResource(core, SampleCapability.class));
+		Assert.assertFalse("SampleCapability should have been removed from the list of known capabilities.",
+				bindingManagement.knownCapabilities.contains(SampleCapability.class));
 	}
 
 	@Test


### PR DESCRIPTION
This pull request fixes a bug in the binding mechanism, as well as introduces tests for the BindingManagement implementation.

The bug's context resides in the ResourceCapabilityTreeController. Whenever the binding mechanism is activated (whether a capability or a resource is added), it iterates over the list of known capabilities, and checks if they're already bound to a resource.

The ResourceCapabilityTreeController is the one responsible of this operation. Old implementation compared two capabilities by checking their implementations, but it has to compare its interfaces, so it avoids to bind two different capability implementations of same type. This feature is fixed in this pull request.

Also tests for the binding mechanism has been included, by checking:

* When capabilityClassRemoved trigger is called, instances of this capability must be unbound
* Capability do not bind to Resource when isSupporting method returns false. 
* Only one implementation for a capability is bound to each Resource when more than one implementation is present.
* A different capability instance in each resource (even they are instances of the same capability class).


Fixes task: 

http://jira.i2cat.net/browse/OPENNAAS-1559