### PR TITLE
Multiple improvements

### DIFF
--- a/api.rest/src/main/java/org/mqnaas/api/AddressLoader.java
+++ b/api.rest/src/main/java/org/mqnaas/api/AddressLoader.java
@@ -80,7 +80,7 @@ public class AddressLoader {
 			String address = (String) wsProperties.get(ADDRESS_PROPERTY);
 
 			try {
-				URI uri = new URI(address);
+				new URI(address);
 			} catch (URISyntaxException e) {
 				log.warn("Malformed URI in WS configuration file. Using defult address: " + DEFAULT_ADDRESS, e);
 				return DEFAULT_ADDRESS;

--- a/api.rest/src/main/java/org/mqnaas/api/AddressLoader.java
+++ b/api.rest/src/main/java/org/mqnaas/api/AddressLoader.java
@@ -79,6 +79,11 @@ public class AddressLoader {
 			Dictionary<String, Object> wsProperties = configAdmin.getConfiguration(ADDRESS_CONFIG_FILE).getProperties();
 			String address = (String) wsProperties.get(ADDRESS_PROPERTY);
 
+			if (address == null) {
+				log.warn("No URI present in WS configuration file. Using defult address: " + DEFAULT_ADDRESS);
+				return DEFAULT_ADDRESS;
+			}
+
 			try {
 				new URI(address);
 			} catch (URISyntaxException e) {

--- a/api.rest/src/main/java/org/mqnaas/api/mapping/APIMapper.java
+++ b/api.rest/src/main/java/org/mqnaas/api/mapping/APIMapper.java
@@ -29,6 +29,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.i2cat.utils.StringBuilderUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A collection of {@link IMethodMapper}s to support mapping from methods from a Web API interface to a Java interface.
@@ -37,6 +39,8 @@ import org.i2cat.utils.StringBuilderUtils;
  * 
  */
 public class APIMapper implements InvocationHandler {
+
+	private static final Logger			log				= LoggerFactory.getLogger(APIMapper.class);
 
 	private Class<?>					interfaceAPI;
 
@@ -56,7 +60,7 @@ public class APIMapper implements InvocationHandler {
 
 	@Override
 	public Object invoke(Object arg0, Method method, Object[] params) throws Throwable {
-		System.out.println("Invoking " + method.getName() + " on " + arg0.getClass() + " with params " + Arrays.toString(params));
+		log.info("Invoking " + method.getName() + " on " + arg0.getClass() + " with params " + Arrays.toString(params));
 
 		MethodMapper mm = methodMappers.get(method);
 

--- a/bundletree/itests/src/test/java/org/mqnaas/bundletree/test/BundleGuardTest.java
+++ b/bundletree/itests/src/test/java/org/mqnaas/bundletree/test/BundleGuardTest.java
@@ -62,10 +62,10 @@ public class BundleGuardTest {
 		// FIXME Read mqnass features version from maven.
 		// now mqnaas features version in this file must be changed manually in each release!
 		return new Option[] {
-				// distribution to test: Karaf 3.0.1
+				// distribution to test: Karaf 3.0.3
 				KarafDistributionOption.karafDistributionConfiguration()
-						.frameworkUrl(CoreOptions.maven().groupId("org.apache.karaf").artifactId("apache-karaf").type("tar.gz").version("3.0.1"))
-						.karafVersion("3.0.1").name("Apache Karaf").useDeployFolder(false)
+						.frameworkUrl(CoreOptions.maven().groupId("org.apache.karaf").artifactId("apache-karaf").type("tar.gz").version("3.0.3"))
+						.karafVersion("3.0.3").name("Apache Karaf").useDeployFolder(false)
 						// keep deployed Karaf
 						.unpackDirectory(new File("target/exam")),
 				// no local and remote consoles

--- a/bundletree/itests/src/test/java/org/mqnaas/bundletree/utils/test/BundleUtilsTest.java
+++ b/bundletree/itests/src/test/java/org/mqnaas/bundletree/utils/test/BundleUtilsTest.java
@@ -61,10 +61,10 @@ public class BundleUtilsTest {
 		// FIXME Read mqnass features version from maven. Same applies for bundletree-itests-testbundleX version
 		// now mqnaas features version in this file must be changed manually in each release!
 		return new Option[] {
-				// distribution to test: Karaf 3.0.1
+				// distribution to test: Karaf 3.0.3
 				KarafDistributionOption.karafDistributionConfiguration()
-						.frameworkUrl(CoreOptions.maven().groupId("org.apache.karaf").artifactId("apache-karaf").type("tar.gz").version("3.0.1"))
-						.karafVersion("3.0.1").name("Apache Karaf").useDeployFolder(false)
+						.frameworkUrl(CoreOptions.maven().groupId("org.apache.karaf").artifactId("apache-karaf").type("tar.gz").version("3.0.3"))
+						.karafVersion("3.0.3").name("Apache Karaf").useDeployFolder(false)
 						// keep deployed Karaf
 						.unpackDirectory(new File("target/exam")),
 				// no local and remote consoles

--- a/extensions/modelreader/modelreader-itests/src/test/java/org/mqnaas/extensions/modelreader/itests/ResourceModelReaderTest.java
+++ b/extensions/modelreader/modelreader-itests/src/test/java/org/mqnaas/extensions/modelreader/itests/ResourceModelReaderTest.java
@@ -104,10 +104,10 @@ public class ResourceModelReaderTest {
 		// FIXME Read mqnass features version from maven.
 		// now mqnaas features version in this file must be changed manually in each release!
 		return new Option[] {
-				// distribution to test: Karaf 3.0.1
+				// distribution to test: Karaf 3.0.3
 				KarafDistributionOption.karafDistributionConfiguration()
-						.frameworkUrl(CoreOptions.maven().groupId("org.apache.karaf").artifactId("apache-karaf").type("tar.gz").version("3.0.1"))
-						.karafVersion("3.0.1").name("Apache Karaf").useDeployFolder(false)
+						.frameworkUrl(CoreOptions.maven().groupId("org.apache.karaf").artifactId("apache-karaf").type("tar.gz").version("3.0.3"))
+						.karafVersion("3.0.3").name("Apache Karaf").useDeployFolder(false)
 						// keep deployed Karaf
 						.unpackDirectory(new File("target/paxexam")),
 				// no local and remote consoles

--- a/extensions/modelreader/pom.xml
+++ b/extensions/modelreader/pom.xml
@@ -13,21 +13,6 @@
 	<name>MQNaaS :: Generic Resource Model Reader</name>
 	<description>Generic implementation exposing the whole model of a resource</description>
 
-	<properties>
-		<mqnaas.version>0.0.1-SNAPSHOT</mqnaas.version>
-		<network.version>0.0.1-SNAPSHOT</network.version>
-		<odl.version>0.0.1-SNAPSHOT</odl.version>
-		
-		
-		<javax.inject.version>1_2</javax.inject.version>
-		<karaf.version>3.0.1</karaf.version>
-		<paxexam.version>3.5.0</paxexam.version>
-		<powermock.version>1.5.5</powermock.version>
-		<wiremock.version>1.51</wiremock.version>
-		
-		
-	</properties>
-
 	<modules>
 		<module>modelreader-capability</module>
 		<module>modelreader-itests</module>
@@ -40,120 +25,8 @@
 				<groupId>org.mqnaas.extensions</groupId>
 				<artifactId>modelreader-capability</artifactId>
 				<version>${project.version}</version>
-			</dependency>		
-			<!-- MQNaaS modules -->
-			<dependency>
-				<groupId>org.mqnaas</groupId>
-				<artifactId>core.api</artifactId>
-				<version>${mqnaas.version}</version>
-			</dependency>
-			<!-- Network modules -->
-			<dependency>
-				<groupId>org.mqnaas.extensions</groupId>
-				<artifactId>network.api</artifactId>
-				<version>${network.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.mqnaas.extensions</groupId>
-				<artifactId>network.impl</artifactId>
-				<version>${network.version}</version>
-			</dependency>
-			<!-- ODL modules -->
-			<dependency>
-				<groupId>org.mqnaas.extensions</groupId>
-				<artifactId>odl.capabilities</artifactId>
-				<version>${odl.version}</version>
-			</dependency>
-			<!-- Tests libraries -->
-			<dependency>
-				<groupId>junit</groupId>
-				<artifactId>junit</artifactId>
-				<scope>test</scope>
-				<version>${junit.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.apache.servicemix.bundles</groupId>
-				<artifactId>org.apache.servicemix.bundles.javax-inject</artifactId>
-				<scope>test</scope>
-				<version>${javax.inject.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.ops4j.pax.exam</groupId>
-				<artifactId>pax-exam-container-karaf</artifactId>
-				<scope>test</scope>
-				<version>${paxexam.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.ops4j.pax.exam</groupId>
-				<artifactId>pax-exam</artifactId>
-				<scope>test</scope>
-				<version>${paxexam.version}</version>				
-			</dependency>
-			<dependency>
-				<groupId>org.ops4j.pax.exam</groupId>
-				<artifactId>pax-exam-junit4</artifactId>
-				<scope>test</scope>
-				<version>${paxexam.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.ops4j.pax.exam</groupId>
-				<artifactId>pax-exam-spi</artifactId>
-				<version>${paxexam.version}</version>				
-			</dependency>
-			<dependency>
-				<groupId>org.apache.karaf</groupId>
-				<artifactId>apache-karaf</artifactId>
-				<type>tar.gz</type>
-				<scope>test</scope>
-				<version>${karaf.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>com.github.tomakehurst</groupId>
-				<artifactId>wiremock</artifactId>
-				<scope>test</scope>
-				<version>${wiremock.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.powermock</groupId>
-				<artifactId>powermock-module-junit4</artifactId>
-				<scope>test</scope>
-				<version>${powermock.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.powermock</groupId>
-				<artifactId>powermock-api-mockito</artifactId>
-				<scope>test</scope>
-				<version>${powermock.version}</version>				
-			</dependency>
-			<dependency>
-				<groupId>org.mqnaas</groupId>
-				<artifactId>test-helpers</artifactId>
-				<version>${mqnaas.version}</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>
-
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
-				</configuration>
-			</plugin>
-			<plugin>
-				<artifactId>maven-resources-plugin</artifactId>
-			</plugin>
-			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>build-helper-maven-plugin</artifactId>
-				<inherited>false</inherited>
-			</plugin>
-		</plugins>
-	</build>
-
 
 </project>

--- a/extensions/network/itests/src/test/java/org/mqnaas/extensions/network/itests/NetworkManagementTest.java
+++ b/extensions/network/itests/src/test/java/org/mqnaas/extensions/network/itests/NetworkManagementTest.java
@@ -98,10 +98,10 @@ public class NetworkManagementTest {
 		// FIXME Read mqnass features version from maven.
 		// now mqnaas features version in this file must be changed manually in each release!
 		return new Option[] {
-				// distribution to test: Karaf 3.0.1
+				// distribution to test: Karaf 3.0.3
 				KarafDistributionOption.karafDistributionConfiguration()
-						.frameworkUrl(CoreOptions.maven().groupId("org.apache.karaf").artifactId("apache-karaf").type("tar.gz").version("3.0.1"))
-						.karafVersion("3.0.1").name("Apache Karaf").useDeployFolder(false)
+						.frameworkUrl(CoreOptions.maven().groupId("org.apache.karaf").artifactId("apache-karaf").type("tar.gz").version("3.0.3"))
+						.karafVersion("3.0.3").name("Apache Karaf").useDeployFolder(false)
 						// keep deployed Karaf
 						.unpackDirectory(new File("target/paxexam")),
 				// no local and remote consoles

--- a/extensions/network/itests/src/test/java/org/mqnaas/extensions/network/itests/ResourcesIntegrationTest.java
+++ b/extensions/network/itests/src/test/java/org/mqnaas/extensions/network/itests/ResourcesIntegrationTest.java
@@ -89,10 +89,10 @@ public class ResourcesIntegrationTest {
 		// FIXME Read mqnass features version from maven.
 		// now mqnaas features version in this file must be changed manually in each release!
 		return new Option[] {
-				// distribution to test: Karaf 3.0.1
+				// distribution to test: Karaf 3.0.3
 				KarafDistributionOption.karafDistributionConfiguration()
-						.frameworkUrl(CoreOptions.maven().groupId("org.apache.karaf").artifactId("apache-karaf").type("tar.gz").version("3.0.1"))
-						.karafVersion("3.0.1").name("Apache Karaf").useDeployFolder(false)
+						.frameworkUrl(CoreOptions.maven().groupId("org.apache.karaf").artifactId("apache-karaf").type("tar.gz").version("3.0.3"))
+						.karafVersion("3.0.3").name("Apache Karaf").useDeployFolder(false)
 						// keep deployed Karaf
 						.unpackDirectory(new File("target/paxexam")),
 				// no local and remote consoles

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -66,7 +66,7 @@
 		<javax.inject.version>1_2</javax.inject.version>
 
 		<!-- Apache Karaf version -->
-		<karaf.version>3.0.1</karaf.version>
+		<karaf.version>3.0.3</karaf.version>
 
 		<!-- Pax Exam version -->
 		<pax.exam.version>3.5.0</pax.exam.version>

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -60,7 +60,7 @@
 		<wiremock.version>1.51</wiremock.version>
 
 		<!-- Powermock version -->
-		<powermock.version>1.5.4</powermock.version>
+		<powermock.version>1.5.5</powermock.version>
 
 		<!-- Javax Inject version -->
 		<javax.inject.version>1_2</javax.inject.version>
@@ -108,6 +108,22 @@
 				<artifactId>test-helpers</artifactId>
 				<version>${mqnaas.version}</version>
 				<scope>test</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.mqnaas.extensions</groupId>
+				<artifactId>network.api</artifactId>
+				<version>${mqnaas.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.mqnaas.extensions</groupId>
+				<artifactId>network.impl</artifactId>
+				<version>${mqnaas.version}</version>
+			</dependency>
+			<!-- ODL modules -->
+			<dependency>
+				<groupId>org.mqnaas.extensions</groupId>
+				<artifactId>odl.capabilities</artifactId>
+				<version>${project.version}</version>
 			</dependency>
 			<!-- Testing libraries -->
 			<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
 		<junit-version>4.11</junit-version>
 
 		<!-- Apache Karaf distribution version -->
-		<karaf-version>3.0.1</karaf-version>
+		<karaf-version>3.0.3</karaf-version>
 
 		<!-- OPS4J Pax Exam version -->
 		<pax-exam-version>3.5.0</pax-exam-version>


### PR DESCRIPTION
* Use Apache Karaf 3.0.3 in integration tests (it supports Oracle Java 8).
* Use logger instead of sysout.
* Improve + AddressLoader` URI checking.
* Clean `ModelReader` POMs.
* Remove some compilation warnings.