### PR TITLE
Improvement/paxexam 4

### DIFF
--- a/extensions/network/pom.xml
+++ b/extensions/network/pom.xml
@@ -62,8 +62,8 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
+					<source>1.7</source>
+					<target>1.7</target>
 				</configuration>
 			</plugin>
 			<!-- Maven resources plugin configured below -->

--- a/extensions/odl/pom.xml
+++ b/extensions/odl/pom.xml
@@ -70,8 +70,8 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
+					<source>1.7</source>
+					<target>1.7</target>
 				</configuration>
 			</plugin>
 			<!-- Maven resources plugin configured below -->

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -69,7 +69,7 @@
 		<karaf.version>3.0.3</karaf.version>
 
 		<!-- Pax Exam version -->
-		<pax.exam.version>3.5.0</pax.exam.version>
+		<pax.exam.version>4.5.0</pax.exam.version>
 
 		<!-- JUnit version -->
 		<junit.version>4.11</junit.version>

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -320,8 +320,8 @@
 					<artifactId>maven-compiler-plugin</artifactId>
 					<version>${maven-compiler-plugin-version}</version>
 					<configuration>
-						<source>1.6</source>
-						<target>1.6</target>
+						<source>1.7</source>
+						<target>1.7</target>
 					</configuration>
 				</plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -299,8 +299,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>${maven-compiler-plugin-version}</version>
 				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
+					<source>1.7</source>
+					<target>1.7</target>
 				</configuration>
 			</plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
 		<karaf-version>3.0.3</karaf-version>
 
 		<!-- OPS4J Pax Exam version -->
-		<pax-exam-version>3.5.0</pax-exam-version>
+		<pax-exam-version>4.5.0</pax-exam-version>
 
 		<!-- PowerMock version -->
 		<powermock.version>1.5.5</powermock.version>


### PR DESCRIPTION
This pull request upgrades the Pax Exam version from 3.5 to 4.5.

Changes of the 4.X version can be found in [official documentation](https://ops4j1.jira.com/wiki/pages/viewpage.action?pageId=54263865)

It contain two mainly constraints:
* Java version >= 1.7
* OSGI version >= 4.3

Therefore, the maven-compiler-plugin has been modified to require, at least, java 7.