### PR TITLE
Improvement/link management to network

### DIFF
--- a/extensions/network/itests/src/test/java/org/mqnaas/extensions/network/itests/ResourcesIntegrationTest.java
+++ b/extensions/network/itests/src/test/java/org/mqnaas/extensions/network/itests/ResourcesIntegrationTest.java
@@ -171,20 +171,6 @@ public class ResourcesIntegrationTest {
 		ILinkManagement linkManagementCapab = serviceProvider.getCapability(networkResource, ILinkManagement.class);
 		Assert.assertNotNull("Network resource should contain a bound ILinkManagement capability.", linkManagementCapab);
 
-		// other resource, for example, tson
-		linkManagementCapab = serviceProvider.getCapability(tsonResource, ILinkManagement.class);
-		Assert.assertNotNull("All RootResources should contain a bound ILinkManagement capability.",
-				linkManagementCapab);
-
-	}
-
-	@Test
-	public void linkAdministrationBindingTest() throws CapabilityNotFoundException, ResourceNotFoundException, InstantiationException,
-			IllegalAccessException, InterruptedException {
-
-		ILinkManagement linkManagementCapab = serviceProvider.getCapability(tsonResource, ILinkManagement.class);
-		Assert.assertNotNull("TSON resource should contain a bound ILinkManagement capability.", linkManagementCapab);
-
 		// link resource capabilities
 		IResource link = linkManagementCapab.createLink();
 		Assert.assertNotNull(link);
@@ -195,6 +181,13 @@ public class ResourcesIntegrationTest {
 
 		// remove created resources
 		linkManagementCapab.removeLink(link);
+	}
+
+	@Test(expected = CapabilityNotFoundException.class)
+	public void linkAdministrationBindingTest() throws CapabilityNotFoundException, ResourceNotFoundException, InstantiationException,
+			IllegalAccessException, InterruptedException {
+
+		serviceProvider.getCapability(tsonResource, ILinkManagement.class);
 
 	}
 

--- a/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/topology/link/LinkManagement.java
+++ b/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/topology/link/LinkManagement.java
@@ -46,7 +46,7 @@ public class LinkManagement implements ILinkManagement {
 	}
 
 	public static boolean isSupporting(IRootResource resource) {
-		return (!resource.getDescriptor().getSpecification().getType().equals(Type.CORE));
+		return (resource.getDescriptor().getSpecification().getType().equals(Type.NETWORK));
 	}
 
 	private List<LinkResource>	links;

--- a/extensions/network/network.impl/src/test/java/org/mqnaas/network/impl/LinkManagementTest.java
+++ b/extensions/network/network.impl/src/test/java/org/mqnaas/network/impl/LinkManagementTest.java
@@ -1,5 +1,26 @@
 package org.mqnaas.network.impl;
 
+/*
+ * #%L
+ * MQNaaS :: Network Implementation
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i
+ * 			Innovació a Catalunya
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Arrays;

--- a/extensions/network/network.impl/src/test/java/org/mqnaas/network/impl/LinkManagementTest.java
+++ b/extensions/network/network.impl/src/test/java/org/mqnaas/network/impl/LinkManagementTest.java
@@ -1,0 +1,72 @@
+package org.mqnaas.network.impl;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Arrays;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.mqnaas.core.api.Endpoint;
+import org.mqnaas.core.api.IRootResource;
+import org.mqnaas.core.api.RootResourceDescriptor;
+import org.mqnaas.core.api.Specification;
+import org.mqnaas.core.api.Specification.Type;
+import org.mqnaas.core.impl.RootResource;
+import org.mqnaas.network.impl.request.RequestResource;
+import org.mqnaas.network.impl.topology.link.LinkManagement;
+
+/**
+ * <p>
+ * Class containing tests for the {@link LinkManagement} capability implementation.
+ * </p>
+ * 
+ * @author Adrián Roselló Rey (i2CAT)
+ *
+ */
+public class LinkManagementTest {
+
+	/**
+	 * Checks that the {@link LinkManagement#isSupporting(org.mqnaas.core.api.IResource)} method defines:
+	 * <ul>
+	 * <li>LinkManagement does not support MQNaaS CORE resource.
+	 * <li>LinkManagement supports generic networks.</li>
+	 * <li>LinkManagement supports NITOS testbed.</li>
+	 * <li>LinkManagement does not support no-network {@link IRootResource}s (for example: Router)</li>
+	 * <li>LinkManagement supports {@link RequestResource}s</li>
+	 * </ul>
+	 * 
+	 * @throws InstantiationException
+	 * @throws IllegalAccessException
+	 * @throws URISyntaxException
+	 */
+	@Test
+	public void isSupportingTest() throws InstantiationException, IllegalAccessException, URISyntaxException {
+
+		// MQNaaS core resource should not be supported.
+		Specification spec = new Specification(Type.CORE);
+		Assert.assertFalse("LinkManagement should be not be bound to MQNaaS CORE resource.",
+				LinkManagement.isSupporting(new RootResource(RootResourceDescriptor.create(spec))));
+
+		// networks without model should be supported.
+		spec = new Specification(Type.NETWORK);
+		Assert.assertTrue("LinkManagement should be bound to networks.",
+				LinkManagement.isSupporting(new RootResource(RootResourceDescriptor.create(spec))));
+
+		// NITOS network should be supported.
+		spec = new Specification(Type.NETWORK, "nitos");
+		Assert.assertTrue("LinkManagement should be bound to networks of type NITOS.",
+				LinkManagement.isSupporting(new RootResource(RootResourceDescriptor.create(spec))));
+
+		// Router should not be supported.
+		spec = new Specification(Type.ROUTER, "junos", "12.10");
+		Endpoint endpoint = new Endpoint(new URI("http://localhost:8080/router1"));
+		Assert.assertFalse("LinkManagement should not be bound to no-network IRootResources.",
+				LinkManagement.isSupporting(new RootResource(RootResourceDescriptor.create(spec, Arrays.asList(endpoint)))));
+
+		// RequestResource should be supported.
+		RequestResource requestResource = new RequestResource();
+		Assert.assertTrue("LinkManagement should be bound to any RequestResource.",
+				LinkManagement.isSupporting(requestResource));
+
+	}
+}


### PR DESCRIPTION
LinkManagement capability did bind to all type of IRootResources, except MQNaaS-Core.

This pull requests restricts this capability to Network resources, no matter if they are virtual, physical or testbeds (like NITOS). Also tests for its "isSupporting" method has been added.

Fixes following story:
http://jira.i2cat.net/browse/CON-128