### PR TITLE
Feature/resource metadata

### DIFF
--- a/core.api/src/main/java/org/mqnaas/core/api/IAttributeStore.java
+++ b/core.api/src/main/java/org/mqnaas/core/api/IAttributeStore.java
@@ -32,9 +32,13 @@ public interface IAttributeStore extends ICapability {
 	/**
 	 * This static can be used by all modules defining a map between an OpenNaaS {@link IResource} and an external component.
 	 */
-	static final String	RESOURCE_EXTERNAL_ID	= "resource.external.id";
+	static final String	RESOURCE_EXTERNAL_ID		= "resource.external.id";
 
-	static final String	RESOURCE_EXTERNAL_NAME	= "resource.external.name";
+	static final String	RESOURCE_EXTERNAL_NAME		= "resource.external.name";
+
+	static final String	RESOURCE_CREATION_TIME		= "resource.creation.time";
+
+	static final String	RESOURCE_CONCLUSION_TIME	= "resource.conclusion.time";
 
 	String getAttribute(String name);
 

--- a/core.api/src/main/java/org/mqnaas/core/api/IAttributeStore.java
+++ b/core.api/src/main/java/org/mqnaas/core/api/IAttributeStore.java
@@ -1,5 +1,6 @@
 package org.mqnaas.core.api;
 
+
 /*
  * #%L
  * MQNaaS :: Core.API
@@ -43,5 +44,7 @@ public interface IAttributeStore extends ICapability {
 	String getAttribute(String name);
 
 	void setAttribute(String name, String value);
+
+	MapWrapper getAttributes();
 
 }

--- a/core.api/src/main/java/org/mqnaas/core/api/MapWrapper.java
+++ b/core.api/src/main/java/org/mqnaas/core/api/MapWrapper.java
@@ -1,0 +1,89 @@
+package org.mqnaas.core.api;
+
+/*
+ * #%L
+ * MQNaaS :: Core.API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
+import java.util.Map;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * 
+ * <p>
+ * Wrapper class to be used by JAXB to serialize {@link Map}s.
+ * </p>
+ * 
+ * TODO Remove this class once our API is able to deal with maps.
+ * 
+ * @author Adrian Rosello Rey (i2CAT)
+ *
+ */
+@XmlRootElement
+@XmlAccessorType(XmlAccessType.FIELD)
+public class MapWrapper {
+
+	Map<String, String>	map;
+
+	public MapWrapper() {
+
+	}
+
+	public MapWrapper(Map<String, String> map) {
+		this.map = map;
+	}
+
+	public Map<String, String> getMap() {
+		return map;
+	}
+
+	public void setMap(Map<String, String> map) {
+		this.map = map;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((map == null) ? 0 : map.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		MapWrapper other = (MapWrapper) obj;
+		if (map == null) {
+			if (other.map != null)
+				return false;
+		} else if (!map.equals(other.map))
+			return false;
+		return true;
+	}
+
+}

--- a/core/src/main/java/org/mqnaas/core/impl/AttributeStore.java
+++ b/core/src/main/java/org/mqnaas/core/impl/AttributeStore.java
@@ -28,6 +28,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.mqnaas.core.api.IAttributeStore;
 import org.mqnaas.core.api.IResource;
 import org.mqnaas.core.api.IRootResource;
+import org.mqnaas.core.api.MapWrapper;
 import org.mqnaas.core.api.annotations.Resource;
 import org.mqnaas.core.api.exceptions.ApplicationActivationException;
 import org.slf4j.Logger;
@@ -80,4 +81,9 @@ public class AttributeStore implements IAttributeStore {
 
 	}
 
+	@Override
+	public MapWrapper getAttributes() {
+		log.info("Getting all attributes of resource " + resource.getId());
+		return new MapWrapper(attributes);
+	}
 }

--- a/core/src/main/java/org/mqnaas/core/impl/BindingManagement.java
+++ b/core/src/main/java/org/mqnaas/core/impl/BindingManagement.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.GregorianCalendar;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -36,6 +37,7 @@ import org.mqnaas.bundletree.IBundleGuard;
 import org.mqnaas.bundletree.IClassFilter;
 import org.mqnaas.bundletree.IClassListener;
 import org.mqnaas.core.api.IApplication;
+import org.mqnaas.core.api.IAttributeStore;
 import org.mqnaas.core.api.IBindingDecider;
 import org.mqnaas.core.api.ICapability;
 import org.mqnaas.core.api.ICoreModelCapability;
@@ -449,6 +451,17 @@ public class BindingManagement implements IServiceProvider, IResourceManagementL
 				}
 			}
 		}
+
+		// set resource creation time, in number of ms since 1970/01/01
+		try {
+			long creationTime = new GregorianCalendar().getTimeInMillis();
+			IAttributeStore attributeStore = getCapability(added.getContent(), IAttributeStore.class);
+			attributeStore.setAttribute(IAttributeStore.RESOURCE_CREATION_TIME, String.valueOf(creationTime));
+
+		} catch (CapabilityNotFoundException c) {
+			log.warn("Could not set creation time metadata in resource " + added.getContent().getId(), c);
+		}
+
 	}
 
 	@Override


### PR DESCRIPTION
This pull request contains features to store resource metadata, by using its AttributeStore capability. Two metadata are proposed by this pull request:

* Resource creation time: Stored by the BindingManagement after it reacts to a "resourceAdded" service execution.
* Resource conclusion time: Stored by the reservation performer, when performing a reservation (at this time, slices and virtual resources are created).

Also another service has been added to the IAttributeStore capability, in order to retrieve all the attributes it manages.

Fixes story: http://jira.i2cat.net/browse/OPENNAAS-1648