### PR TITLE
Create OpenStack resource and client providers

### DIFF
--- a/core.api/src/main/java/org/mqnaas/core/api/Specification.java
+++ b/core.api/src/main/java/org/mqnaas/core/api/Specification.java
@@ -75,7 +75,7 @@ public class Specification implements Cloneable {
 		 */
 		LTE("LTE"),
 		/**
-		 * Client premises equiment
+		 * Client premises equipment
 		 */
 		CPE("CPE"),
 		/**
@@ -86,6 +86,10 @@ public class Specification implements Cloneable {
 		 * Wifi
 		 */
 		CHANNEL("CHANNEL"),
+		/**
+		 * Cloud Manager
+		 */
+		CLOUD_MANAGER("Cloud-Manager"),
 		/**
 		 * Other devices
 		 */

--- a/core.api/src/main/java/org/mqnaas/core/api/credentials/Credentials.java
+++ b/core.api/src/main/java/org/mqnaas/core/api/credentials/Credentials.java
@@ -26,7 +26,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlSeeAlso;
 
 @XmlRootElement(namespace = "org.mqnaas")
-@XmlSeeAlso({ TrustoreKeystoreCredentials.class, UsernamePasswordCredentials.class })
+@XmlSeeAlso({ TrustoreKeystoreCredentials.class, UsernamePasswordCredentials.class, UsernamePasswordTenantCredentials.class })
 public abstract class Credentials {
 
 }

--- a/core.api/src/main/java/org/mqnaas/core/api/credentials/UsernamePasswordTenantCredentials.java
+++ b/core.api/src/main/java/org/mqnaas/core/api/credentials/UsernamePasswordTenantCredentials.java
@@ -1,0 +1,117 @@
+package org.mqnaas.core.api.credentials;
+
+/*
+ * #%L
+ * MQNaaS :: Core.API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * Credentials based on user name, password and tenant name.
+ * 
+ * @author Julio Carlos Barrera (i2CAT Foundation)
+ *
+ */
+@XmlRootElement(namespace = "org.mqnaas")
+@XmlAccessorType(XmlAccessType.FIELD)
+public class UsernamePasswordTenantCredentials extends Credentials {
+
+	private String	userName;
+	private String	password;
+	private String	tenant;
+
+	public UsernamePasswordTenantCredentials() {
+	}
+
+	public UsernamePasswordTenantCredentials(String userName, String password, String tenant) {
+		this.userName = userName;
+		this.password = password;
+		this.tenant = tenant;
+	}
+
+	public String getUserName() {
+		return userName;
+	}
+
+	public void setUserName(String userName) {
+		this.userName = userName;
+	}
+
+	public String getPassword() {
+		return password;
+	}
+
+	public void setPassword(String password) {
+		this.password = password;
+	}
+
+	public String getTenant() {
+		return tenant;
+	}
+
+	public void setTenant(String tenant) {
+		this.tenant = tenant;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((password == null) ? 0 : password.hashCode());
+		result = prime * result + ((tenant == null) ? 0 : tenant.hashCode());
+		result = prime * result + ((userName == null) ? 0 : userName.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		UsernamePasswordTenantCredentials other = (UsernamePasswordTenantCredentials) obj;
+		if (password == null) {
+			if (other.password != null)
+				return false;
+		} else if (!password.equals(other.password))
+			return false;
+		if (tenant == null) {
+			if (other.tenant != null)
+				return false;
+		} else if (!tenant.equals(other.tenant))
+			return false;
+		if (userName == null) {
+			if (other.userName != null)
+				return false;
+		} else if (!userName.equals(other.userName))
+			return false;
+		return true;
+	}
+
+	@Override
+	public String toString() {
+		return "UsernamePasswordTenantCredentials [userName=" + userName + ", password=****, tenant=" + tenant + "]";
+	}
+}

--- a/core/src/test/java/org/mqnaas/core/impl/dependency_injection/DependencyInjectionTests.java
+++ b/core/src/test/java/org/mqnaas/core/impl/dependency_injection/DependencyInjectionTests.java
@@ -107,8 +107,8 @@ public class DependencyInjectionTests {
 						.version("0.0.1-SNAPSHOT"), "mqnaas"),
 				// install mqnaas-test-helpers bundle
 				CoreOptions.mavenBundle().groupId("org.mqnaas").artifactId("mqnaas-test-helpers").version("0.0.1-SNAPSHOT"),
-				// debug option
-				KarafDistributionOption.debugConfiguration()
+		// debug option
+		// KarafDistributionOption.debugConfiguration()
 		};
 	}
 
@@ -128,7 +128,7 @@ public class DependencyInjectionTests {
 
 	@Ignore
 	@Test
-	public void rootResourceProiderInjectionTest() throws IllegalArgumentException, IllegalAccessException, CapabilityNotFoundException {
+	public void rootResourceProviderInjectionTest() throws IllegalArgumentException, IllegalAccessException, CapabilityNotFoundException {
 		// get ISampleCapability instances of each resourceA instance
 		ISampleCapability resourceA1SampleCapabilityInstance = serviceProvider.getCapabilityInstance(resourceAInstance1, ISampleCapability.class);
 		ISampleCapability resourceA2SampleCapabilityInstance = serviceProvider.getCapabilityInstance(resourceAInstance2, ISampleCapability.class);

--- a/extensions/openstack/jclouds-client-provider/pom.xml
+++ b/extensions/openstack/jclouds-client-provider/pom.xml
@@ -13,8 +13,19 @@
 
 	<name>MQNaaS :: JClouds Client Provider</name>
 	<description>JClouds Client Provider</description>
-	
+
 	<dependencies>
+		<!-- Apache jClouds -->
+		<dependency>
+			<groupId>org.apache.jclouds</groupId>
+			<artifactId>jclouds-all</artifactId>
+			<version>${jclouds.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.jclouds.labs</groupId>
+			<artifactId>openstack-neutron</artifactId>
+			<version>${jclouds.version}</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/extensions/openstack/jclouds-client-provider/pom.xml
+++ b/extensions/openstack/jclouds-client-provider/pom.xml
@@ -26,6 +26,24 @@
 			<artifactId>openstack-neutron</artifactId>
 			<version>${jclouds.version}</version>
 		</dependency>
+		<!-- MQNaaS modules -->
+		<dependency>
+			<groupId>org.mqnaas</groupId>
+			<artifactId>core.api</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.mqnaas</groupId>
+			<artifactId>clientprovider-api</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.mqnaas</groupId>
+			<artifactId>clientprovider</artifactId>
+		</dependency>
+		<!-- SLF4J logging API -->
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>
@@ -36,8 +54,14 @@
 				<extensions>true</extensions>
 				<configuration>
 					<instructions>
-						<Import-Package>*</Import-Package>
+						<Import-Package>
+							<!-- hidden package by Java proxies, manually imported -->
+							org.mqnaas.clientprovider.exceptions,
+							*
+						</Import-Package>
 						<Export-Package>
+							org.mqnaas.extensions.openstack.jclouds.clientprovider,
+							org.mqnaas.extensions.openstack.jclouds.clientprovider.internal
 						</Export-Package>
 					</instructions>
 				</configuration>

--- a/extensions/openstack/jclouds-client-provider/pom.xml
+++ b/extensions/openstack/jclouds-client-provider/pom.xml
@@ -1,0 +1,36 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.mqnaas.extensions</groupId>
+		<artifactId>openstack</artifactId>
+		<version>0.0.1-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>jclouds-client-provider</artifactId>
+	<packaging>bundle</packaging>
+
+	<name>MQNaaS :: JClouds Client Provider</name>
+	<description>JClouds Client Provider</description>
+	
+	<dependencies>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.felix</groupId>
+				<artifactId>maven-bundle-plugin</artifactId>
+				<extensions>true</extensions>
+				<configuration>
+					<instructions>
+						<Import-Package>*</Import-Package>
+						<Export-Package>
+						</Export-Package>
+					</instructions>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/extensions/openstack/jclouds-client-provider/src/main/java/org/mqnaas/extensions/openstack/jclouds/clientprovider/IJCloudsNeutronClientProvider.java
+++ b/extensions/openstack/jclouds-client-provider/src/main/java/org/mqnaas/extensions/openstack/jclouds/clientprovider/IJCloudsNeutronClientProvider.java
@@ -1,0 +1,34 @@
+package org.mqnaas.extensions.openstack.jclouds.clientprovider;
+
+/*
+ * #%L
+ * MQNaaS :: JClouds Client Provider
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i
+ * 			Innovació a Catalunya
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import org.jclouds.openstack.neutron.v2.NeutronApi;
+import org.mqnaas.clientprovider.api.client.IClientProvider;
+
+/**
+ * {@link IClientProvider} to obtain a client for jClouds OpenStack Neutron API based on interface {@link NeutronApi}.
+ * 
+ * @author Julio Carlos Barrera (i2CAT Foundation)
+ *
+ */
+public interface IJCloudsNeutronClientProvider extends IClientProvider<NeutronApi, Object> {
+}

--- a/extensions/openstack/jclouds-client-provider/src/main/java/org/mqnaas/extensions/openstack/jclouds/clientprovider/IJCloudsNovaClientProvider.java
+++ b/extensions/openstack/jclouds-client-provider/src/main/java/org/mqnaas/extensions/openstack/jclouds/clientprovider/IJCloudsNovaClientProvider.java
@@ -1,0 +1,34 @@
+package org.mqnaas.extensions.openstack.jclouds.clientprovider;
+
+/*
+ * #%L
+ * MQNaaS :: JClouds Client Provider
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i
+ * 			Innovació a Catalunya
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import org.jclouds.openstack.nova.v2_0.NovaApi;
+import org.mqnaas.clientprovider.api.client.IClientProvider;
+
+/**
+ * {@link IClientProvider} to obtain a client for jClouds OpenStack Nova API based on interface {@link NovaApi}.
+ * 
+ * @author Julio Carlos Barrera (i2CAT Foundation)
+ *
+ */
+public interface IJCloudsNovaClientProvider extends IClientProvider<NovaApi, Object> {
+}

--- a/extensions/openstack/jclouds-client-provider/src/main/java/org/mqnaas/extensions/openstack/jclouds/clientprovider/internal/InternalJCloudsNeutronClientProvider.java
+++ b/extensions/openstack/jclouds-client-provider/src/main/java/org/mqnaas/extensions/openstack/jclouds/clientprovider/internal/InternalJCloudsNeutronClientProvider.java
@@ -1,0 +1,69 @@
+package org.mqnaas.extensions.openstack.jclouds.clientprovider.internal;
+
+/*
+ * #%L
+ * MQNaaS :: JClouds Client Provider
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i
+ * 			Innovació a Catalunya
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import org.jclouds.ContextBuilder;
+import org.jclouds.openstack.neutron.v2.NeutronApi;
+import org.mqnaas.clientprovider.api.client.IInternalClientProvider;
+import org.mqnaas.core.api.Endpoint;
+import org.mqnaas.core.api.credentials.Credentials;
+import org.mqnaas.core.api.credentials.UsernamePasswordTenantCredentials;
+
+/**
+ * jClouds OpenStack Neutron {@link IInternalClientProvider}. No configuration allowed.
+ * 
+ * @author Julio Carlos Barrera (i2CAT Foundation)
+ *
+ */
+public class InternalJCloudsNeutronClientProvider implements IInternalClientProvider<NeutronApi, Object> {
+
+	@Override
+	public String[] getProtocols() {
+		return new String[] { "http", "https" };
+	}
+
+	@Override
+	public NeutronApi getClient(Endpoint ep, Credentials c) {
+		if (!(c instanceof UsernamePasswordTenantCredentials)) {
+			throw new IllegalStateException(
+					"InternalJCloudsNeutronClientProvider requires UsernamePasswordTenantCredentials! Provided: " + c.getClass());
+		}
+
+		String userName = ((UsernamePasswordTenantCredentials) c).getUserName();
+		String password = ((UsernamePasswordTenantCredentials) c).getPassword();
+		String tenant = ((UsernamePasswordTenantCredentials) c).getTenant();
+
+		if (ep == null || ep.getUri() == null) {
+			throw new IllegalStateException("InternalJCloudsNeutronClientProvider requires a valid endpoint URI! Provided: " + ep);
+		}
+
+		String uri = (String) ep.getUri().toString();
+
+		return ContextBuilder.newBuilder("openstack-neutron").endpoint(uri).credentials(tenant + ":" + userName, password).buildApi(NeutronApi.class);
+	}
+
+	@Override
+	public NeutronApi getClient(Endpoint ep, Credentials c, Object configuration) {
+		return getClient(ep, c);
+	}
+
+}

--- a/extensions/openstack/jclouds-client-provider/src/main/java/org/mqnaas/extensions/openstack/jclouds/clientprovider/internal/InternalJCloudsNovaClientProvider.java
+++ b/extensions/openstack/jclouds-client-provider/src/main/java/org/mqnaas/extensions/openstack/jclouds/clientprovider/internal/InternalJCloudsNovaClientProvider.java
@@ -1,0 +1,68 @@
+package org.mqnaas.extensions.openstack.jclouds.clientprovider.internal;
+
+/*
+ * #%L
+ * MQNaaS :: JClouds Client Provider
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i
+ * 			Innovació a Catalunya
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import org.jclouds.ContextBuilder;
+import org.jclouds.openstack.nova.v2_0.NovaApi;
+import org.mqnaas.clientprovider.api.client.IInternalClientProvider;
+import org.mqnaas.core.api.Endpoint;
+import org.mqnaas.core.api.credentials.Credentials;
+import org.mqnaas.core.api.credentials.UsernamePasswordTenantCredentials;
+
+/**
+ * jClouds OpenStack Nova {@link IInternalClientProvider}. No configuration allowed.
+ * 
+ * @author Julio Carlos Barrera (i2CAT Foundation)
+ *
+ */
+public class InternalJCloudsNovaClientProvider implements IInternalClientProvider<NovaApi, Object> {
+
+	@Override
+	public String[] getProtocols() {
+		return new String[] { "http", "https" };
+	}
+
+	@Override
+	public NovaApi getClient(Endpoint ep, Credentials c) {
+		if (!(c instanceof UsernamePasswordTenantCredentials)) {
+			throw new IllegalStateException("InternalJCloudsNovaClientProvider requires UsernamePasswordTenantCredentials! Provided: " + c.getClass());
+		}
+
+		String userName = ((UsernamePasswordTenantCredentials) c).getUserName();
+		String password = ((UsernamePasswordTenantCredentials) c).getPassword();
+		String tenant = ((UsernamePasswordTenantCredentials) c).getTenant();
+
+		if (ep == null || ep.getUri() == null) {
+			throw new IllegalStateException("InternalJCloudsNovaClientProvider requires a valid endpoint URI! Provided: " + ep);
+		}
+
+		String uri = (String) ep.getUri().toString();
+
+		return ContextBuilder.newBuilder("openstack-nova").endpoint(uri).credentials(tenant + ":" + userName, password).buildApi(NovaApi.class);
+	}
+
+	@Override
+	public NovaApi getClient(Endpoint ep, Credentials c, Object configuration) {
+		return getClient(ep, c);
+	}
+
+}

--- a/extensions/openstack/openstack-api/pom.xml
+++ b/extensions/openstack/openstack-api/pom.xml
@@ -1,0 +1,36 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.mqnaas.extensions</groupId>
+		<artifactId>openstack</artifactId>
+		<version>0.0.1-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>openstack.api</artifactId>
+	<packaging>bundle</packaging>
+
+	<name>MQNaaS :: OpenStack API</name>
+	<description>OpenStack Capabilities APIs and models</description>
+	
+	<dependencies>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.felix</groupId>
+				<artifactId>maven-bundle-plugin</artifactId>
+				<extensions>true</extensions>
+				<configuration>
+					<instructions>
+						<Import-Package>*</Import-Package>
+						<Export-Package>
+						</Export-Package>
+					</instructions>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/extensions/openstack/openstack-api/pom.xml
+++ b/extensions/openstack/openstack-api/pom.xml
@@ -8,7 +8,7 @@
 		<version>0.0.1-SNAPSHOT</version>
 	</parent>
 
-	<artifactId>openstack.api</artifactId>
+	<artifactId>openstack-api</artifactId>
 	<packaging>bundle</packaging>
 
 	<name>MQNaaS :: OpenStack API</name>

--- a/extensions/openstack/openstack-impl/pom.xml
+++ b/extensions/openstack/openstack-impl/pom.xml
@@ -1,0 +1,36 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.mqnaas.extensions</groupId>
+		<artifactId>openstack</artifactId>
+		<version>0.0.1-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>openstack.impl</artifactId>
+	<packaging>bundle</packaging>
+
+	<name>MQNaaS :: OpenStack Implementation</name>
+	<description>MQNaaS OpenStack capabilities implementations</description>
+
+	<dependencies>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.felix</groupId>
+				<artifactId>maven-bundle-plugin</artifactId>
+				<extensions>true</extensions>
+				<configuration>
+					<instructions>
+						<Import-Package>*</Import-Package>
+						<Export-Package>
+						</Export-Package>
+					</instructions>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/extensions/openstack/openstack-impl/pom.xml
+++ b/extensions/openstack/openstack-impl/pom.xml
@@ -8,7 +8,7 @@
 		<version>0.0.1-SNAPSHOT</version>
 	</parent>
 
-	<artifactId>openstack.impl</artifactId>
+	<artifactId>openstack-impl</artifactId>
 	<packaging>bundle</packaging>
 
 	<name>MQNaaS :: OpenStack Implementation</name>

--- a/extensions/openstack/openstack-itests/pom.xml
+++ b/extensions/openstack/openstack-itests/pom.xml
@@ -1,0 +1,116 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.mqnaas.extensions</groupId>
+		<artifactId>openstack</artifactId>
+		<version>0.0.1-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>openstack-itests</artifactId>
+	<packaging>bundle</packaging>
+
+	<name>MQNaaS :: OpenStack iTests</name>
+	<description>OpenStack extension integration tests</description>
+
+	<dependencies>
+		<!-- Own modules -->
+		<dependency>
+			<groupId>org.mqnaas.extensions</groupId>
+			<artifactId>jclouds-client-provider</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.mqnaas.extensions</groupId>
+			<artifactId>openstack-api</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.mqnaas.extensions</groupId>
+			<artifactId>openstack-impl</artifactId>
+		</dependency>
+		<!-- MQNaaS modules -->
+		<dependency>
+			<groupId>org.mqnaas</groupId>
+			<artifactId>core.api</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.mqnaas</groupId>
+			<artifactId>core</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.mqnaas</groupId>
+			<artifactId>test-helpers</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.mqnaas</groupId>
+			<artifactId>clientprovider-api</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.mqnaas</groupId>
+			<artifactId>clientprovider</artifactId>
+		</dependency>
+		<!-- SLF4J logging API -->
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+		</dependency>
+		<!-- SLF4J Simple for tests binding -->
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-simple</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<!-- Test dependencies -->
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.servicemix.bundles</groupId>
+			<artifactId>org.apache.servicemix.bundles.javax-inject</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.ops4j.pax.exam</groupId>
+			<artifactId>pax-exam-container-karaf</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.ops4j.pax.exam</groupId>
+			<artifactId>pax-exam</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.ops4j.pax.exam</groupId>
+			<artifactId>pax-exam-junit4</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.ops4j.pax.exam</groupId>
+			<artifactId>pax-exam-spi</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.karaf</groupId>
+			<artifactId>apache-karaf</artifactId>
+			<type>tar.gz</type>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.felix</groupId>
+				<artifactId>maven-bundle-plugin</artifactId>
+				<extensions>true</extensions>
+				<configuration>
+					<instructions>
+						<Import-Package>*</Import-Package>
+						<Export-Package></Export-Package>
+					</instructions>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/extensions/openstack/openstack-itests/src/test/java/org/mqnaas/extensions/openstack/jclouds/clientprovider/JCloudsClientProvidersTest.java
+++ b/extensions/openstack/openstack-itests/src/test/java/org/mqnaas/extensions/openstack/jclouds/clientprovider/JCloudsClientProvidersTest.java
@@ -1,0 +1,162 @@
+package org.mqnaas.extensions.openstack.jclouds.clientprovider;
+
+/*
+ * #%L
+ * MQNaaS :: JClouds Client Provider
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i
+ * 			Innovació a Catalunya
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import java.io.File;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Arrays;
+
+import javax.inject.Inject;
+
+import org.jclouds.openstack.neutron.v2.NeutronApi;
+import org.jclouds.openstack.nova.v2_0.NovaApi;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mqnaas.clientprovider.api.client.IClientProvider;
+import org.mqnaas.clientprovider.api.client.IClientProviderFactory;
+import org.mqnaas.clientprovider.exceptions.EndpointNotFoundException;
+import org.mqnaas.clientprovider.exceptions.ProviderNotFoundException;
+import org.mqnaas.core.api.Endpoint;
+import org.mqnaas.core.api.ICoreProvider;
+import org.mqnaas.core.api.IRootResource;
+import org.mqnaas.core.api.IRootResourceAdministration;
+import org.mqnaas.core.api.IServiceProvider;
+import org.mqnaas.core.api.RootResourceDescriptor;
+import org.mqnaas.core.api.Specification;
+import org.mqnaas.core.api.Specification.Type;
+import org.mqnaas.core.api.credentials.Credentials;
+import org.mqnaas.core.api.credentials.UsernamePasswordTenantCredentials;
+import org.mqnaas.core.api.exceptions.CapabilityNotFoundException;
+import org.mqnaas.core.api.exceptions.ResourceNotFoundException;
+import org.ops4j.pax.exam.Configuration;
+import org.ops4j.pax.exam.CoreOptions;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.exam.karaf.options.KarafDistributionOption;
+import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
+import org.ops4j.pax.exam.spi.reactors.PerClass;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * jClouds {@link IClientProvider}'s tests.
+ * 
+ * @author Julio Carlos Barrera (i2CAT Foundation)
+ *
+ */
+@RunWith(PaxExam.class)
+@ExamReactorStrategy(PerClass.class)
+public class JCloudsClientProvidersTest {
+
+	private static final Logger			log	= LoggerFactory.getLogger(JCloudsClientProvidersTest.class);
+
+	@Inject
+	private ICoreProvider				coreProvider;
+
+	@Inject
+	private IServiceProvider			serviceProvider;
+
+	@Inject
+	private IRootResourceAdministration	rootResourceMgmt;
+
+	private IClientProviderFactory		clientProviderFactory;
+
+	private IRootResource				openStackResource;
+
+	@Configuration
+	public Option[] config() {
+		// FIXME Read mqnass features version from maven.
+		// now mqnaas features version in this file must be changed manually in each release!
+		return new Option[] {
+				// distribution to test: Karaf 3.0.3
+				KarafDistributionOption.karafDistributionConfiguration()
+						.frameworkUrl(CoreOptions.maven().groupId("org.apache.karaf").artifactId("apache-karaf").type("tar.gz").version("3.0.3"))
+						.karafVersion("3.0.3").name("Apache Karaf").useDeployFolder(false)
+						// keep deployed Karaf
+						.unpackDirectory(new File("target/paxexam")),
+				// no local and remote consoles
+				KarafDistributionOption.configureConsole().ignoreLocalConsole(),
+				KarafDistributionOption.configureConsole().ignoreRemoteShell(),
+				// keep runtime folder allowing analysing results
+				KarafDistributionOption.keepRuntimeFolder(),
+				// use custom logging configuration file with a custom appender
+				KarafDistributionOption.replaceConfigurationFile("etc/org.ops4j.pax.logging.cfg", new File(
+						"src/test/resources/org.ops4j.pax.logging.cfg")),
+				// maintain our log configuration
+				KarafDistributionOption.doNotModifyLogConfiguration(),
+				// add MQNaaS feature
+				KarafDistributionOption.features(
+						CoreOptions.maven().groupId("org.mqnaas").artifactId("mqnaas").classifier("features").type("xml").version("0.0.1-SNAPSHOT"),
+						"mqnaas"),
+				// add MQNaaS OpenStack feature
+				KarafDistributionOption.features(
+						CoreOptions.maven().groupId("org.mqnaas.extensions").artifactId("openstack").classifier("features").type("xml")
+								.version("0.0.1-SNAPSHOT"), "mqnaas-openstack"),
+				// install mqnaas-test-helpers bundle
+				CoreOptions.mavenBundle().groupId("org.mqnaas").artifactId("mqnaas-test-helpers").version("0.0.1-SNAPSHOT"),
+				// debug option
+				KarafDistributionOption.debugConfiguration()
+		};
+	}
+
+	@Before
+	public void init() throws CapabilityNotFoundException, InstantiationException, IllegalAccessException, URISyntaxException {
+		IRootResource coreResource = coreProvider.getCore();
+		clientProviderFactory = serviceProvider.getCapability(coreResource, IClientProviderFactory.class);
+
+		openStackResource = createOpenStackResource(Type.CLOUD_MANAGER, "openstack", "http://example:12345/", "userName", "password", "tenantName");
+	}
+
+	@After
+	public void removeResources() throws ResourceNotFoundException {
+		rootResourceMgmt.removeRootResource(openStackResource);
+	}
+
+	@Test
+	public void clientProviderTest() throws IllegalArgumentException, IllegalAccessException, CapabilityNotFoundException,
+			ProviderNotFoundException, EndpointNotFoundException {
+		// get client providers from factory
+		IJCloudsNovaClientProvider jCloudsNovaClientProvider = clientProviderFactory.getClientProvider(IJCloudsNovaClientProvider.class);
+		IJCloudsNeutronClientProvider jCloudsNeutronClientProvider = clientProviderFactory.getClientProvider(IJCloudsNeutronClientProvider.class);
+
+		// get clients
+		NovaApi novaClient = jCloudsNovaClientProvider.getClient(openStackResource);
+		NeutronApi neutronClient = jCloudsNeutronClientProvider.getClient(openStackResource);
+
+		// assert client instances non-nullity
+		Assert.assertNotNull("Nova client must be defined", novaClient);
+		Assert.assertNotNull("Neutron client must be defined", neutronClient);
+	}
+
+	private IRootResource createOpenStackResource(Specification.Type resourceType, String resourceModel, String endpointURI, String userName,
+			String password, String tenantName) throws InstantiationException, IllegalAccessException, URISyntaxException {
+		Specification spec = new Specification(resourceType, resourceModel);
+		Endpoint endpoint = new Endpoint(new URI(endpointURI));
+		Credentials credentials = new UsernamePasswordTenantCredentials(userName, password, tenantName);
+
+		return rootResourceMgmt.createRootResource(RootResourceDescriptor.create(spec, Arrays.asList(endpoint), credentials));
+	}
+}

--- a/extensions/openstack/openstack-itests/src/test/resources/org.ops4j.pax.logging.cfg
+++ b/extensions/openstack/openstack-itests/src/test/resources/org.ops4j.pax.logging.cfg
@@ -1,0 +1,56 @@
+################################################################################
+#
+#    Licensed to the Apache Software Foundation (ASF) under one or more
+#    contributor license agreements.  See the NOTICE file distributed with
+#    this work for additional information regarding copyright ownership.
+#    The ASF licenses this file to You under the Apache License, Version 2.0
+#    (the "License"); you may not use this file except in compliance with
+#    the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+################################################################################
+
+# Root logger
+log4j.rootLogger=INFO, out, osgi:*
+log4j.throwableRenderer=org.apache.log4j.OsgiThrowableRenderer
+
+# CONSOLE appender not used by default
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{ISO8601} | %-5.5p | %-16.16t | %-32.32c{1} | %X{bundle.id} - %X{bundle.name} - %X{bundle.version} | %m%n
+
+# File appender
+log4j.appender.out=org.apache.log4j.RollingFileAppender
+log4j.appender.out.layout=org.apache.log4j.PatternLayout
+log4j.appender.out.layout.ConversionPattern=%d{ISO8601} | %-5.5p | %-16.16t | %-32.32c{1} | %X{bundle.id} - %X{bundle.name} - %X{bundle.version} | %m%n
+log4j.appender.out.file=${karaf.data}/log/karaf.log
+log4j.appender.out.append=true
+log4j.appender.out.maxFileSize=1MB
+log4j.appender.out.maxBackupIndex=10
+
+# Sift appender
+log4j.appender.sift=org.apache.log4j.sift.MDCSiftingAppender
+log4j.appender.sift.key=bundle.name
+log4j.appender.sift.default=karaf
+log4j.appender.sift.appender=org.apache.log4j.FileAppender
+log4j.appender.sift.appender.layout=org.apache.log4j.PatternLayout
+log4j.appender.sift.appender.layout.ConversionPattern=%d{ISO8601} | %-5.5p | %-16.16t | %-32.32c{1} | %m%n
+log4j.appender.sift.appender.file=${karaf.data}/log/$\\{bundle.name\\}.log
+log4j.appender.sift.appender.append=true
+
+# MQNaaS appender
+log4j.logger.org.mqnaas = TRACE, mqnaas
+log4j.appender.mqnaas=org.apache.log4j.RollingFileAppender
+log4j.appender.mqnaas.layout=org.apache.log4j.PatternLayout
+log4j.appender.mqnaas.layout.ConversionPattern=%d{ISO8601} | %-5.5p | %-16.16t | %-32.32c{1} | %X{bundle.id} - %X{bundle.name} - %X{bundle.version} | %m%n
+log4j.appender.mqnaas.file=${karaf.data}/log/mqnaas.log
+log4j.appender.mqnaas.append=true
+log4j.appender.mqnaas.maxFileSize=100MB
+log4j.appender.mqnaas.maxBackupIndex=10

--- a/extensions/openstack/pom.xml
+++ b/extensions/openstack/pom.xml
@@ -19,6 +19,7 @@
 		<module>jclouds-client-provider</module>
 		<module>openstack-api</module>
 		<module>openstack-impl</module>
+		<module>openstack-itests</module>
 	</modules>
 
 	<properties>
@@ -41,6 +42,11 @@
 			<dependency>
 				<groupId>org.mqnaas.extensions</groupId>
 				<artifactId>openstack-impl</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.mqnaas.extensions</groupId>
+				<artifactId>openstack-itests</artifactId>
 				<version>${project.version}</version>
 			</dependency>
 		</dependencies>

--- a/extensions/openstack/pom.xml
+++ b/extensions/openstack/pom.xml
@@ -22,6 +22,7 @@
 	</modules>
 
 	<properties>
+		<jclouds.version>1.8.1</jclouds.version>
 	</properties>
 
 	<dependencyManagement>

--- a/extensions/openstack/pom.xml
+++ b/extensions/openstack/pom.xml
@@ -1,0 +1,64 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.mqnaas.extensions</groupId>
+		<artifactId>extensions</artifactId>
+		<version>0.0.1-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>openstack</artifactId>
+	<packaging>pom</packaging>
+
+	<name>MQNaaS :: OpenStack</name>
+	<description>MQNaaS OpenStack Resource Capabilities</description>
+
+	<modules>
+		<module>jclouds-client-provider</module>
+		<module>openstack-api</module>
+		<module>openstack-impl</module>
+	</modules>
+
+	<properties>
+	</properties>
+
+	<dependencyManagement>
+		<dependencies>
+			<!-- Own modules -->
+			<dependency>
+				<groupId>org.mqnaas.extensions</groupId>
+				<artifactId>jclouds-client-provider</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.mqnaas.extensions</groupId>
+				<artifactId>openstack-api</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.mqnaas.extensions</groupId>
+				<artifactId>openstack-impl</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
+	<build>
+		<plugins>
+			<!-- Maven resources plugin configured below -->
+			<plugin>
+				<artifactId>maven-resources-plugin</artifactId>
+			</plugin>
+
+			<!-- Build helper Maven plugin configured below -->
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>build-helper-maven-plugin</artifactId>
+				<inherited>false</inherited>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/extensions/openstack/src/main/resources/features.xml
+++ b/extensions/openstack/src/main/resources/features.xml
@@ -2,18 +2,14 @@
 <features xmlns="http://karaf.apache.org/xmlns/features/v1.0.0">
 
 	<repository>mvn:org.apache.jclouds.karaf/jclouds-karaf/${jclouds.version}/xml/features</repository>
-	<repository>mvn:org.opennaas/org.opennaas.extensions.protocols.features/${project.version}/xml/features</repository>
 
-
-	<feature name="mqnaas-openstack" version="${project.version}">
-		<feature version="${project.version}">opennaas-protocol-http</feature>
-
+	<feature name="mqnaas-jclouds" version="${project.version}">
 		<feature version="${jclouds.version}">jclouds</feature>
 		<feature version="${jclouds.version}">jclouds-api-openstack-keystone</feature>
 		<feature version="${jclouds.version}">jclouds-api-openstack-nova</feature>
 
 		<bundle dependency="true">wrap:mvn:org.apache.jclouds.labs/openstack-neutron/${jclouds.version}$overwrite=merge&amp;Import-Package=com.google.common.base;version=&quot;[17.0,18)&quot;,com.google.common.cache;version=&quot;[17.0,18)&quot;,com.google.common.collect;version=&quot;[17.0,18)&quot;,com.google.gson.annotations;version=&quot;[2.2,3)&quot;,com.google.inject;version=&quot;[1.3,2)&quot;,com.google.inject.binder;version=&quot;[1.3,2)&quot;,javax.inject,javax.ws.rs;version=&quot;[1.1,2)&quot;,org.jclouds;version=&quot;${jclouds.version}&quot;,org.jclouds.apis;version=&quot;${jclouds.version}&quot;,org.jclouds.apis.internal;version=&quot;${jclouds.version}&quot;,org.jclouds.collect;version=&quot;${jclouds.version}&quot;,org.jclouds.collect.internal;version=&quot;${jclouds.version}&quot;,org.jclouds.http;version=&quot;${jclouds.version}&quot;,org.jclouds.http.annotation;version=&quot;${jclouds.version}&quot;,org.jclouds.http.functions;version=&quot;${jclouds.version}&quot;,org.jclouds.io;version=&quot;${jclouds.version}&quot;,org.jclouds.javax.annotation;version=&quot;${jclouds.version}&quot;,org.jclouds.json;version=&quot;${jclouds.version}&quot;,org.jclouds.json.config;version=&quot;${jclouds.version}&quot;,org.jclouds.location;version=&quot;${jclouds.version}&quot;,org.jclouds.location.functions;version=&quot;${jclouds.version}&quot;,org.jclouds.openstack.keystone.v2_0;version=&quot;${jclouds.version}&quot;,org.jclouds.openstack.keystone.v2_0.config;version=&quot;${jclouds.version}&quot;,org.jclouds.openstack.keystone.v2_0.filters;version=&quot;${jclouds.version}&quot;,org.jclouds.openstack.v2_0.domain;version=&quot;${jclouds.version}&quot;,org.jclouds.openstack.v2_0.features;version=&quot;${jclouds.version}&quot;,org.jclouds.openstack.v2_0.functions;version=&quot;${jclouds.version}&quot;,org.jclouds.openstack.v2_0.options;version=&quot;${jclouds.version}&quot;,org.jclouds.openstack.v2_0.services;version=&quot;${jclouds.version}&quot;,org.jclouds.rest;version=&quot;${jclouds.version}&quot;,org.jclouds.rest.annotations;version=&quot;${jclouds.version}&quot;,org.jclouds.rest.binders;version=&quot;${jclouds.version}&quot;,org.jclouds.rest.config;version=&quot;${jclouds.version}&quot;,org.jclouds.rest.functions;version=&quot;${jclouds.version}&quot;,org.jclouds.rest.internal;version=&quot;${jclouds.version}&quot;,org.jclouds.util;version=&quot;${jclouds.version}&quot;&amp;Export-Package=org.jclouds.openstack.neutron.v2;version=&quot;${jclouds.version}&quot;,org.jclouds.openstack.neutron.v2.domain;version=&quot;${jclouds.version}&quot;,org.jclouds.openstack.neutron.v2.features;version=&quot;${jclouds.version}&quot;</bundle>
 
-		<bundle>mvn:org.opennaas/org.opennaas.extensions.openstack/${project.version}</bundle>
+		<bundle>mvn:org.mqnaas.extensions/jclouds-client-provider/${project.version}</bundle>
 	</feature>
 </features>

--- a/extensions/openstack/src/main/resources/features.xml
+++ b/extensions/openstack/src/main/resources/features.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<features xmlns="http://karaf.apache.org/xmlns/features/v1.0.0">
+
+	<repository>mvn:org.apache.jclouds.karaf/jclouds-karaf/${jclouds.version}/xml/features</repository>
+	<repository>mvn:org.opennaas/org.opennaas.extensions.protocols.features/${project.version}/xml/features</repository>
+
+
+	<feature name="mqnaas-openstack" version="${project.version}">
+		<feature version="${project.version}">opennaas-protocol-http</feature>
+
+		<feature version="${jclouds.version}">jclouds</feature>
+		<feature version="${jclouds.version}">jclouds-api-openstack-keystone</feature>
+		<feature version="${jclouds.version}">jclouds-api-openstack-nova</feature>
+
+		<bundle dependency="true">wrap:mvn:org.apache.jclouds.labs/openstack-neutron/${jclouds.version}$overwrite=merge&amp;Import-Package=com.google.common.base;version=&quot;[17.0,18)&quot;,com.google.common.cache;version=&quot;[17.0,18)&quot;,com.google.common.collect;version=&quot;[17.0,18)&quot;,com.google.gson.annotations;version=&quot;[2.2,3)&quot;,com.google.inject;version=&quot;[1.3,2)&quot;,com.google.inject.binder;version=&quot;[1.3,2)&quot;,javax.inject,javax.ws.rs;version=&quot;[1.1,2)&quot;,org.jclouds;version=&quot;${jclouds.version}&quot;,org.jclouds.apis;version=&quot;${jclouds.version}&quot;,org.jclouds.apis.internal;version=&quot;${jclouds.version}&quot;,org.jclouds.collect;version=&quot;${jclouds.version}&quot;,org.jclouds.collect.internal;version=&quot;${jclouds.version}&quot;,org.jclouds.http;version=&quot;${jclouds.version}&quot;,org.jclouds.http.annotation;version=&quot;${jclouds.version}&quot;,org.jclouds.http.functions;version=&quot;${jclouds.version}&quot;,org.jclouds.io;version=&quot;${jclouds.version}&quot;,org.jclouds.javax.annotation;version=&quot;${jclouds.version}&quot;,org.jclouds.json;version=&quot;${jclouds.version}&quot;,org.jclouds.json.config;version=&quot;${jclouds.version}&quot;,org.jclouds.location;version=&quot;${jclouds.version}&quot;,org.jclouds.location.functions;version=&quot;${jclouds.version}&quot;,org.jclouds.openstack.keystone.v2_0;version=&quot;${jclouds.version}&quot;,org.jclouds.openstack.keystone.v2_0.config;version=&quot;${jclouds.version}&quot;,org.jclouds.openstack.keystone.v2_0.filters;version=&quot;${jclouds.version}&quot;,org.jclouds.openstack.v2_0.domain;version=&quot;${jclouds.version}&quot;,org.jclouds.openstack.v2_0.features;version=&quot;${jclouds.version}&quot;,org.jclouds.openstack.v2_0.functions;version=&quot;${jclouds.version}&quot;,org.jclouds.openstack.v2_0.options;version=&quot;${jclouds.version}&quot;,org.jclouds.openstack.v2_0.services;version=&quot;${jclouds.version}&quot;,org.jclouds.rest;version=&quot;${jclouds.version}&quot;,org.jclouds.rest.annotations;version=&quot;${jclouds.version}&quot;,org.jclouds.rest.binders;version=&quot;${jclouds.version}&quot;,org.jclouds.rest.config;version=&quot;${jclouds.version}&quot;,org.jclouds.rest.functions;version=&quot;${jclouds.version}&quot;,org.jclouds.rest.internal;version=&quot;${jclouds.version}&quot;,org.jclouds.util;version=&quot;${jclouds.version}&quot;&amp;Export-Package=org.jclouds.openstack.neutron.v2;version=&quot;${jclouds.version}&quot;,org.jclouds.openstack.neutron.v2.domain;version=&quot;${jclouds.version}&quot;,org.jclouds.openstack.neutron.v2.features;version=&quot;${jclouds.version}&quot;</bundle>
+
+		<bundle>mvn:org.opennaas/org.opennaas.extensions.openstack/${project.version}</bundle>
+	</feature>
+</features>

--- a/extensions/openstack/src/main/resources/features.xml
+++ b/extensions/openstack/src/main/resources/features.xml
@@ -3,6 +3,14 @@
 
 	<repository>mvn:org.apache.jclouds.karaf/jclouds-karaf/${jclouds.version}/xml/features</repository>
 
+	<feature name="mqnaas-openstack" version="${project.version}">
+		<feature version="${project.version}">mqnaas-jclouds</feature>
+
+		<bundle>mvn:org.mqnaas.extensions/jclouds-client-provider/${project.version}</bundle>
+		<bundle>mvn:org.mqnaas.extensions/openstack-api/${project.version}</bundle>
+		<bundle>mvn:org.mqnaas.extensions/openstack-impl/${project.version}</bundle>
+	</feature>
+
 	<feature name="mqnaas-jclouds" version="${project.version}">
 		<feature version="${jclouds.version}">jclouds</feature>
 		<feature version="${jclouds.version}">jclouds-api-openstack-keystone</feature>

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -17,6 +17,7 @@
 		<module>network</module>
 		<module>odl</module>
 		<module>modelreader</module>
+		<module>openstack</module>
 	</modules>
 
 	<licenses>

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -111,6 +111,17 @@
 				<scope>test</scope>
 			</dependency>
 			<dependency>
+				<groupId>org.mqnaas</groupId>
+				<artifactId>clientprovider-api</artifactId>
+				<version>${mqnaas.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.mqnaas</groupId>
+				<artifactId>clientprovider</artifactId>
+				<version>${mqnaas.version}</version>
+			</dependency>
+			<!-- Network modules -->
+			<dependency>
 				<groupId>org.mqnaas.extensions</groupId>
 				<artifactId>network.api</artifactId>
 				<version>${mqnaas.version}</version>


### PR DESCRIPTION
Create new RootResource `openstack` of type `Cloud-Manager`. Added [jClouds](http://jclouds.apache.org/) Nova and Neutron client providers in order to offer remote clients to be used by capabilities.