### PR TITLE
Dummy UserManagement capability.

### DIFF
--- a/core.api/pom.xml
+++ b/core.api/pom.xml
@@ -65,6 +65,7 @@
 						<Import-Package>*</Import-Package>
 						<Export-Package>
 							org.mqnaas.core.api,
+							org.mqnaas.core.api.user,
 							org.mqnaas.core.api.annotations,
 							org.mqnaas.core.api.credentials,
 							org.mqnaas.core.api.exceptions,

--- a/core.api/src/main/java/org/mqnaas/core/api/user/IResourceAssignation.java
+++ b/core.api/src/main/java/org/mqnaas/core/api/user/IResourceAssignation.java
@@ -1,0 +1,71 @@
+package org.mqnaas.core.api.user;
+
+/*
+ * #%L
+ * MQNaaS :: Core.API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
+import org.mqnaas.core.api.ICapability;
+import org.mqnaas.core.api.IRootResource;
+
+/**
+ * <p>
+ * Capability managing the assignment of resources to specific users.
+ * </p>
+ * 
+ * @author Adrian Rosello Rey (i2CAT)
+ *
+ */
+public interface IResourceAssignation extends ICapability {
+
+	/**
+	 * Returns a list of the ids of the {@link IRootResource}s assigned to a specific user.
+	 * 
+	 * @param username
+	 *            Id of a framework's user.
+	 * @return Wrapper class providing the ids of the resources assigned to given user.
+	 */
+	Resources getByUser(String username);
+
+	/**
+	 * Assign a specific {@link IRootResource} to a specific user. Only unassigned resources can be assigned to a user.
+	 * 
+	 * @param resourceId
+	 *            Id of the resource to be assigned.
+	 * @param username
+	 *            Id of the user that will be bound to the resource.
+	 * @throws IllegalStateException
+	 *             If the resource is already assigned to this or another user.
+	 */
+	void assign(String resourceId, String username) throws IllegalStateException;
+
+	/**
+	 * Unassign a specific {@link IRootResource} from a specific user. A resource can only be unassigned if it's already assigned to that user.
+	 * 
+	 * @param resourceId
+	 *            Id of the resource to be unassigned.
+	 * @param username
+	 *            Id of the user the resource was bound to.
+	 * @throws IllegalStateException
+	 *             If given resource is not assigned to specified user, or it has been not assigned to any user yet.
+	 */
+	void unassign(String resourceId, String username) throws IllegalStateException;
+
+}

--- a/core.api/src/main/java/org/mqnaas/core/api/user/IUserManagement.java
+++ b/core.api/src/main/java/org/mqnaas/core/api/user/IUserManagement.java
@@ -1,0 +1,47 @@
+package org.mqnaas.core.api.user;
+
+import org.mqnaas.core.api.ICapability;
+
+/*
+ * #%L
+ * MQNaaS :: Core.API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
+/**
+ * <p>
+ * Capability managing the list of users of the MQNaaS framework.
+ * </p>
+ * <p>
+ * First draft of the capability defines users as {@link String}s representing the username.
+ * </p>
+ * 
+ * @author Adrian Rosello Rey (i2CAT)
+ *
+ */
+public interface IUserManagement extends ICapability {
+
+	/**
+	 * Return all the usernames of the framework users.
+	 * 
+	 * @return {@link User} wrapper class, containing the list of all usernames of the MQNaaS framework.
+	 */
+	Users getUsers();
+
+}

--- a/core.api/src/main/java/org/mqnaas/core/api/user/Resources.java
+++ b/core.api/src/main/java/org/mqnaas/core/api/user/Resources.java
@@ -1,0 +1,97 @@
+package org.mqnaas.core.api.user;
+
+/*
+ * #%L
+ * MQNaaS :: Core.API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
+import java.util.List;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import org.mqnaas.core.api.IRootResource;
+
+/**
+ * <p>
+ * Wrapper class for the ids of MQNaaS {@link IRootResource}s. This class is required until the API provides the ability to wrap a {@link List}
+ * </p>
+ * 
+ * 
+ * TODO remove and (replace it) once the API serialize lists.
+ * 
+ * @author Adrian Rosello Rey (i2CAT)
+ *
+ */
+@XmlRootElement
+@XmlAccessorType(XmlAccessType.FIELD)
+public class Resources {
+
+	@XmlElement(name = "resourceId")
+	private List<String>	resourcesIds;
+
+	public Resources() {
+	}
+
+	public Resources(List<String> resourcesIds) {
+		this.resourcesIds = resourcesIds;
+	}
+
+	public List<String> getResourcesIds() {
+		return resourcesIds;
+	}
+
+	public void setResourcesIds(List<String> resourcesIds) {
+		this.resourcesIds = resourcesIds;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((resourcesIds == null) ? 0 : resourcesIds.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		Resources other = (Resources) obj;
+		if (resourcesIds == null) {
+			if (other.resourcesIds != null)
+				return false;
+		} else if (!resourcesIds.equals(other.resourcesIds))
+			return false;
+		return true;
+	}
+
+	@Override
+	public String toString() {
+		return "Resources [resourcesIds=" + resourcesIds + "]";
+	}
+
+}

--- a/core.api/src/main/java/org/mqnaas/core/api/user/Users.java
+++ b/core.api/src/main/java/org/mqnaas/core/api/user/Users.java
@@ -1,0 +1,97 @@
+package org.mqnaas.core.api.user;
+
+/*
+ * #%L
+ * MQNaaS :: Core.API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
+import java.util.List;
+import java.util.Set;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * <p>
+ * Wrapper class for the usernames of the MQNaaS users. This class is required until the API provides the ability to wrap a {@link List}
+ * </p>
+ * 
+ * 
+ * TODO remove and (replace it) once the API serialize lists.
+ * 
+ * @author Adrian Rosello Rey (i2CAT)
+ *
+ */
+@XmlRootElement
+@XmlAccessorType(XmlAccessType.FIELD)
+public class Users {
+
+	@XmlElement(name = "user")
+	Set<String>	usernames;
+
+	public Users() {
+
+	}
+
+	public Users(Set<String> users) {
+		this.usernames = users;
+	}
+
+	public Set<String> getUser() {
+		return usernames;
+	}
+
+	public void setUser(Set<String> user) {
+		this.usernames = user;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((usernames == null) ? 0 : usernames.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		Users other = (Users) obj;
+		if (usernames == null) {
+			if (other.usernames != null)
+				return false;
+		} else if (!usernames.equals(other.usernames))
+			return false;
+		return true;
+	}
+
+	@Override
+	public String toString() {
+		return "Users [users=" + usernames + "]";
+	}
+
+}

--- a/core/src/main/java/org/mqnaas/core/impl/ResourceAssignment.java
+++ b/core/src/main/java/org/mqnaas/core/impl/ResourceAssignment.java
@@ -1,0 +1,114 @@
+package org.mqnaas.core.impl;
+
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.mqnaas.core.api.IResource;
+import org.mqnaas.core.api.IRootResource;
+import org.mqnaas.core.api.Specification;
+import org.mqnaas.core.api.annotations.Resource;
+import org.mqnaas.core.api.exceptions.ApplicationActivationException;
+import org.mqnaas.core.api.user.IResourceAssignation;
+import org.mqnaas.core.api.user.Resources;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * 
+ * @author Adrian Rosello Rey (i2CAT)
+ *
+ */
+public class ResourceAssignment implements IResourceAssignation {
+
+	private static final Logger	LOG	= LoggerFactory.getLogger(ResourceAssignment.class);
+
+	@Resource
+	IResource					resource;
+
+	/**
+	 * Map containing the assignation between resources ids and usernames. Key=resourceId, Value=username
+	 */
+	Map<String, String>			resourcesAssignations;
+
+	public static boolean isSupporting(IRootResource resource) {
+		return resource.getDescriptor().getSpecification().getType().equals(Specification.Type.CORE);
+	}
+
+	@Override
+	public void activate() throws ApplicationActivationException {
+		LOG.info("Initializing ResourceAssignment capability for resource " + resource.getId());
+		resourcesAssignations = new HashMap<String, String>();
+		LOG.info("Initialized ResourceAssignment capability for resource " + resource.getId());
+	}
+
+	@Override
+	public void deactivate() {
+		LOG.info("Removing ResourceAssignment capability from resource " + resource.getId());
+		resourcesAssignations.clear();
+		LOG.info("Removing ResourceAssignment capability from resource " + resource.getId());
+	}
+
+	@Override
+	public Resources getByUser(String username) {
+		LOG.info("Getting resources assigned to user " + username);
+
+		List<String> resources = new ArrayList<String>();
+
+		for (String resource : resourcesAssignations.keySet())
+			if (resourcesAssignations.get(resource).equals(username))
+				resources.add(resource);
+
+		return new Resources(resources);
+	}
+
+	@Override
+	public void assign(String resourceId, String username) throws IllegalStateException {
+		LOG.info("Assigning resource to user: [resourceId=" + resourceId, "username=" + username + "]");
+
+		if (resourcesAssignations.containsKey(resourceId))
+			throw new IllegalStateException("Resource " + resourceId + " is already assigned to this or another user. Please unassign it first.");
+
+		resourcesAssignations.put(resourceId, username);
+
+		LOG.info("Resource successfully assigned 	to user: [resourceId=" + resourceId, "username=" + username + "]");
+
+	}
+
+	@Override
+	public void unassign(String resourceId, String username) {
+		LOG.info("Unassigning resource from user: [resourceId=" + resourceId, "username=" + username + "]");
+		if (!resourcesAssignations.containsKey(resourceId) || !resourcesAssignations.get(resourceId).equals(username))
+			throw new IllegalStateException(
+					"Resource " + resourceId + " either is not assigned to this user or it has been not assigned to any user yet.");
+
+		resourcesAssignations.remove(resourceId);
+
+		LOG.info("Resource successfully unassigned from user: [resourceId=" + resourceId, "username=" + username + "]");
+
+	}
+
+}

--- a/core/src/main/java/org/mqnaas/core/impl/ResourceAssignment.java
+++ b/core/src/main/java/org/mqnaas/core/impl/ResourceAssignment.java
@@ -69,7 +69,7 @@ public class ResourceAssignment implements IResourceAssignation {
 	public void deactivate() {
 		LOG.info("Removing ResourceAssignment capability from resource " + resource.getId());
 		resourcesAssignations.clear();
-		LOG.info("Removing ResourceAssignment capability from resource " + resource.getId());
+		LOG.info("Removed ResourceAssignment capability from resource " + resource.getId());
 	}
 
 	@Override

--- a/core/src/main/java/org/mqnaas/core/impl/UserManagement.java
+++ b/core/src/main/java/org/mqnaas/core/impl/UserManagement.java
@@ -54,7 +54,7 @@ import org.slf4j.LoggerFactory;
  */
 public class UserManagement implements IUserManagement {
 
-	private static final Logger	LOG					= LoggerFactory.getLogger(BindingManagement.class);
+	private static final Logger	LOG					= LoggerFactory.getLogger(UserManagement.class);
 
 	private static final String	USERS_CONFIG_FILE	= "etc/org.mqnaas.users";
 

--- a/core/src/main/java/org/mqnaas/core/impl/UserManagement.java
+++ b/core/src/main/java/org/mqnaas/core/impl/UserManagement.java
@@ -73,7 +73,7 @@ public class UserManagement implements IUserManagement {
 		try {
 			readUsersFromConfigFile();
 		} catch (IOException e) {
-			LOG.warn("Could not read users from configuration file. File does not exists.");
+			throw new ApplicationActivationException("Could not read users from configuration file. File does not exists.");
 		}
 		LOG.info("Initialized UserManagement capability for resource " + resource.getId());
 

--- a/core/src/main/java/org/mqnaas/core/impl/UserManagement.java
+++ b/core/src/main/java/org/mqnaas/core/impl/UserManagement.java
@@ -1,0 +1,104 @@
+package org.mqnaas.core.impl;
+
+/*
+ * #%L
+ * MQNaaS :: Core
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.apache.commons.lang3.StringUtils;
+import org.mqnaas.core.api.IResource;
+import org.mqnaas.core.api.IRootResource;
+import org.mqnaas.core.api.Specification;
+import org.mqnaas.core.api.annotations.Resource;
+import org.mqnaas.core.api.exceptions.ApplicationActivationException;
+import org.mqnaas.core.api.user.IUserManagement;
+import org.mqnaas.core.api.user.Users;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * <p>
+ * Basic implementation of the {@link IUserManagement} capability.
+ * </p>
+ * <p>
+ * This capability binds only to Core resource. During activation process, it reads the list of users from a configuration file located in the karaf
+ * configuration folder.
+ * </p>
+ * 
+ * 
+ * @author Adrian Rosello Rey (i2CAT)
+ *
+ */
+public class UserManagement implements IUserManagement {
+
+	private static final Logger	LOG					= LoggerFactory.getLogger(BindingManagement.class);
+
+	private static final String	USERS_CONFIG_FILE	= "etc/org.mqnaas.users";
+
+	Set<String>					users;
+
+	@Resource
+	IResource					resource;
+
+	public static boolean isSupporting(IRootResource resource) {
+		return resource.getDescriptor().getSpecification().getType().equals(Specification.Type.CORE);
+	}
+
+	@Override
+	public void activate() throws ApplicationActivationException {
+		LOG.info("Initializing UserManagement capability for resource " + resource.getId());
+		try {
+			readUsersFromConfigFile();
+		} catch (IOException e) {
+			LOG.warn("Could not read users from configuration file. File does not exists.");
+		}
+		LOG.info("Initialized UserManagement capability for resource " + resource.getId());
+
+	}
+
+	@Override
+	public void deactivate() {
+		users.clear();
+	}
+
+	@Override
+	public Users getUsers() {
+		return new Users(users);
+	}
+
+	private void readUsersFromConfigFile() throws IOException {
+
+		users = new HashSet<String>();
+
+		BufferedReader br = new BufferedReader(new FileReader(USERS_CONFIG_FILE));
+
+		String user;
+		while ((user = br.readLine()) != null)
+			if (!StringUtils.isEmpty(user))
+				users.add(user);
+
+	}
+}


### PR DESCRIPTION
This pull request introduces first draft of the UserManagement capability.

In this first version, UserManagement capability provides only getter methods. Users are loaded from configuration file during capability activation, so it's not a dynamic system. User consists only of its usernames.

Also it's now available the capability to assign resources to users. It's done by mapping resourcesIds and usernames.

That's the minimal requirement for CONTENT and SODALES demos.

Fixes: http://jira.i2cat.net/browse/OPENNAAS-1658 and http://jira.i2cat.net/browse/OPENNAAS-1606