### PR TITLE
Modelreader prints all the attributes of a resource, in a generic way.

### DIFF
--- a/extensions/modelreader/modelreader-capability/src/main/java/org/mqnaas/extensions/modelreader/api/ResourceModelWrapper.java
+++ b/extensions/modelreader/modelreader-capability/src/main/java/org/mqnaas/extensions/modelreader/api/ResourceModelWrapper.java
@@ -22,7 +22,9 @@ package org.mqnaas.extensions.modelreader.api;
  */
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
@@ -52,9 +54,7 @@ public class ResourceModelWrapper {
 	@XmlElement(required = true)
 	private String						type;
 
-	private String						externalId;
-
-	private String						externalName;
+	private Map<String, String>			attributes;
 
 	@XmlElementWrapper(name = "resources")
 	@XmlElement(name = "resource")
@@ -82,20 +82,14 @@ public class ResourceModelWrapper {
 		this.type = type;
 	}
 
-	public String getExternalId() {
-		return externalId;
+	public Map<String, String> getAttributes() {
+		if (attributes == null)
+			attributes = new HashMap<String, String>();
+		return attributes;
 	}
 
-	public void setExternalId(String externalId) {
-		this.externalId = externalId;
-	}
-
-	public String getExternalName() {
-		return externalName;
-	}
-
-	public void setExternalName(String externalName) {
-		this.externalName = externalName;
+	public void setAttributes(Map<String, String> attributes) {
+		this.attributes = attributes;
 	}
 
 	public List<ResourceModelWrapper> getResources() {
@@ -122,9 +116,8 @@ public class ResourceModelWrapper {
 	public int hashCode() {
 		final int prime = 31;
 		int result = 1;
+		result = prime * result + ((attributes == null) ? 0 : attributes.hashCode());
 		result = prime * result + ((configuredRules == null) ? 0 : configuredRules.hashCode());
-		result = prime * result + ((externalId == null) ? 0 : externalId.hashCode());
-		result = prime * result + ((externalName == null) ? 0 : externalName.hashCode());
 		result = prime * result + ((id == null) ? 0 : id.hashCode());
 		result = prime * result + ((resources == null) ? 0 : resources.hashCode());
 		result = prime * result + ((type == null) ? 0 : type.hashCode());
@@ -140,20 +133,15 @@ public class ResourceModelWrapper {
 		if (getClass() != obj.getClass())
 			return false;
 		ResourceModelWrapper other = (ResourceModelWrapper) obj;
+		if (attributes == null) {
+			if (other.attributes != null)
+				return false;
+		} else if (!attributes.equals(other.attributes))
+			return false;
 		if (configuredRules == null) {
 			if (other.configuredRules != null)
 				return false;
 		} else if (!configuredRules.equals(other.configuredRules))
-			return false;
-		if (externalId == null) {
-			if (other.externalId != null)
-				return false;
-		} else if (!externalId.equals(other.externalId))
-			return false;
-		if (externalName == null) {
-			if (other.externalName != null)
-				return false;
-		} else if (!externalName.equals(other.externalName))
 			return false;
 		if (id == null) {
 			if (other.id != null)
@@ -175,7 +163,7 @@ public class ResourceModelWrapper {
 
 	@Override
 	public String toString() {
-		return "ResourceModelWrapper [id=" + id + ", type=" + type + ", externalId=" + externalId + ", externalName=" + externalName + ", resources=" + resources + ", configuredRules=" + configuredRules + "]";
+		return "ResourceModelWrapper [id=" + id + ", type=" + type + ", attributes=" + attributes + ", resources=" + resources + ", configuredRules=" + configuredRules + "]";
 	}
 
 }

--- a/extensions/modelreader/modelreader-capability/src/test/java/org/mqnaas/extensions/modelreader/ResourceModelWrapperSerializationTest.java
+++ b/extensions/modelreader/modelreader-capability/src/test/java/org/mqnaas/extensions/modelreader/ResourceModelWrapperSerializationTest.java
@@ -30,6 +30,7 @@ import org.apache.commons.io.IOUtils;
 import org.custommonkey.xmlunit.XMLAssert;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mqnaas.core.api.IAttributeStore;
 import org.mqnaas.core.api.Specification;
 import org.mqnaas.extensions.modelreader.api.ResourceModelWrapper;
 import org.mqnaas.general.test.helpers.serialization.SerializationUtils;
@@ -61,6 +62,8 @@ public class ResourceModelWrapperSerializationTest {
 		String serializedXml = SerializationUtils.toXml(resourceModelWrapper);
 		String expectedXml = IOUtils.toString(this.getClass().getResourceAsStream(RESULT_FILE));
 
+		System.out.println(serializedXml);
+
 		XMLAssert.assertXMLEqual("Serialized xml should be equals to the expected one.", expectedXml, serializedXml);
 
 	}
@@ -80,11 +83,11 @@ public class ResourceModelWrapperSerializationTest {
 
 		ResourceModelWrapper switchPort1 = new ResourceModelWrapper(PORT1_RESOURCE_ID);
 		switchPort1.setType("port");
-		switchPort1.setExternalId(PORT1_EXTERNAL_ID);
+		switchPort1.getAttributes().put(IAttributeStore.RESOURCE_EXTERNAL_ID, PORT1_EXTERNAL_ID);
 
 		ResourceModelWrapper switchPort2 = new ResourceModelWrapper(PORT2_RESOURCE_ID);
 		switchPort2.setType("port");
-		switchPort2.setExternalId(PORT2_EXTERNAL_ID);
+		switchPort2.getAttributes().put(IAttributeStore.RESOURCE_EXTERNAL_ID, PORT2_EXTERNAL_ID);
 
 		ResourceModelWrapper switchModel = new ResourceModelWrapper(SWITCH_RESOURCE_ID);
 		switchModel.setType(Specification.Type.OF_SWITCH.toString());
@@ -96,5 +99,4 @@ public class ResourceModelWrapperSerializationTest {
 
 		return networkModel;
 	}
-
 }

--- a/extensions/modelreader/modelreader-capability/src/test/resources/serialization/resourceModelWrapper.xml
+++ b/extensions/modelreader/modelreader-capability/src/test/resources/serialization/resourceModelWrapper.xml
@@ -10,14 +10,25 @@
                 <resource>
                     <id>port-1</id>
                     <type>port</type>
-                    <externalId>eth0</externalId>
+                    <attributes>
+                        <entry>
+                            <key>resource.external.id</key>
+                            <value>eth0</value>
+                        </entry>
+                    </attributes>
                 </resource>
                 <resource>
                     <id>port-2</id>
                     <type>port</type>
-                    <externalId>eth1</externalId>
+                    <attributes>
+                        <entry>
+                            <key>resource.external.id</key>
+                            <value>eth1</value>
+                        </entry>
+                    </attributes>
                 </resource>
             </resources>
         </resource>
     </resources>
 </ns2:resource>
+

--- a/extensions/modelreader/modelreader-itests/src/test/java/org/mqnaas/extensions/modelreader/itests/ResourceModelReaderTest.java
+++ b/extensions/modelreader/modelreader-itests/src/test/java/org/mqnaas/extensions/modelreader/itests/ResourceModelReaderTest.java
@@ -41,6 +41,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mqnaas.core.api.Endpoint;
+import org.mqnaas.core.api.IAttributeStore;
 import org.mqnaas.core.api.IRootResource;
 import org.mqnaas.core.api.IRootResourceAdministration;
 import org.mqnaas.core.api.IRootResourceProvider;
@@ -197,7 +198,8 @@ public class ResourceModelReaderTest {
 		Assert.assertNotNull("Switch model should not be null.", switchModel);
 		Assert.assertEquals("Switch resource representation in model should be of type " + Type.OF_SWITCH, Type.OF_SWITCH.toString(),
 				switchModel.getType());
-		Assert.assertEquals("Switch model should contain as external id " + OF_SWITCH_EXT_ID, OF_SWITCH_EXT_ID, switchModel.getExternalId());
+		Assert.assertEquals("Switch model should contain as external id " + OF_SWITCH_EXT_ID, OF_SWITCH_EXT_ID,
+				switchModel.getAttributes().get(IAttributeStore.RESOURCE_EXTERNAL_ID));
 		Assert.assertEquals("Switch model representation should contain 2 subresources.", 2, switchModel.getResources().size());
 		Assert.assertNull("Switch model should not contain any openflow rules!", switchModel.getConfiguredRules());
 
@@ -215,13 +217,15 @@ public class ResourceModelReaderTest {
 		Assert.assertNull("Ports should not contain any openflow rule!", port1Model.getConfiguredRules());
 		Assert.assertNull("Ports should not contain any openflow rule!", port2Model.getConfiguredRules());
 
-		Assert.assertEquals("First model port should contain the expected external port id. ", OFSWITCH_PORT1_EXT_ID, port1Model.getExternalId());
+		Assert.assertEquals("First model port should contain the expected external port id. ", OFSWITCH_PORT1_EXT_ID,
+				port1Model.getAttributes().get(IAttributeStore.RESOURCE_EXTERNAL_ID));
 		Assert.assertEquals("First model port should contain the expected external port name. ", OFSWITCH_PORT1_EXT_NAME,
-				port1Model.getExternalName());
+				port1Model.getAttributes().get(IAttributeStore.RESOURCE_EXTERNAL_NAME));
 
-		Assert.assertEquals("Second model port should contain the expected external port id. ", OFSWITCH_PORT2_EXT_ID, port2Model.getExternalId());
+		Assert.assertEquals("Second model port should contain the expected external port id. ", OFSWITCH_PORT2_EXT_ID, port2Model.getAttributes()
+				.get(IAttributeStore.RESOURCE_EXTERNAL_ID));
 		Assert.assertEquals("Second model port should contain the expected external port name. ", OFSWITCH_PORT2_EXT_NAME,
-				port2Model.getExternalName());
+				port2Model.getAttributes().get(IAttributeStore.RESOURCE_EXTERNAL_NAME));
 	}
 
 	private IResourceModelReader createClient(String addressUri) {


### PR DESCRIPTION
Just before this pull request, the modelReader searched for specific attributes in the AttributeStore capability of a resource to print them (external_name and external_id)

Now it uses the IAttributeStore.getAllAttributes() method and print all metadata without parsing them.

Fixes task: http://jira.i2cat.net/browse/OPENNAAS-1657