### PR TITLE
Feature/vi slicing units

### DIFF
--- a/extensions/network/itests/src/test/java/org/mqnaas/extensions/network/itests/NetworkManagementTest.java
+++ b/extensions/network/itests/src/test/java/org/mqnaas/extensions/network/itests/NetworkManagementTest.java
@@ -202,14 +202,9 @@ public class NetworkManagementTest {
 		virtualLink.setSrcPort(virtualPort1);
 		virtualLink.setDstPort(virtualPort2);
 
-		// create port slice units in both switches
+		// get slices of virtual resources - they were automatically created from mapped physical device.
 		Slice switch1Slice = new Slice(virtualSwitch1.getSlice(), serviceProvider);
-		Unit portUnitSlice1 = switch1Slice.addUnit(PORT_UNIT_NAME);
-		portUnitSlice1.setRange(new Range(0, 1));
-
 		Slice switch2Slice = new Slice(virtualSwitch2.getSlice(), serviceProvider);
-		Unit portUnitSlice2 = switch2Slice.addUnit(PORT_UNIT_NAME);
-		portUnitSlice2.setRange(new Range(0, 1));
 
 		// initialize slice cubes with one port in both switches
 		Range[] switch1Range = new Range[1];

--- a/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/request/RequestResourceMapping.java
+++ b/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/request/RequestResourceMapping.java
@@ -26,9 +26,20 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.mqnaas.core.api.IResource;
+import org.mqnaas.core.api.IRootResource;
+import org.mqnaas.core.api.IServiceProvider;
+import org.mqnaas.core.api.annotations.DependingOn;
 import org.mqnaas.core.api.annotations.Resource;
 import org.mqnaas.core.api.exceptions.ApplicationActivationException;
+import org.mqnaas.core.api.exceptions.CapabilityNotFoundException;
+import org.mqnaas.core.api.slicing.ISliceProvider;
+import org.mqnaas.core.impl.slicing.Slice;
+import org.mqnaas.core.impl.slicing.SliceResource;
+import org.mqnaas.core.impl.slicing.SliceableResource;
+import org.mqnaas.core.impl.slicing.Unit;
 import org.mqnaas.network.api.request.IRequestResourceMapping;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Implementation of the {@link IRequestResourceMapping} capability using a {@link ConcurrentHashMap}. This implementation is bound to the
@@ -38,11 +49,17 @@ import org.mqnaas.network.api.request.IRequestResourceMapping;
  * infrastructure.
  * 
  * @author Georg Mansky-Kummert
+ * @author Adrián Roselló Rey (i2CAT)
  */
 public class RequestResourceMapping implements IRequestResourceMapping {
 
+	private static final Logger			log	= LoggerFactory.getLogger(RequestResourceMapping.class);
+
 	@Resource
 	IResource							resource;
+
+	@DependingOn
+	IServiceProvider					serviceProvider;
 
 	private Map<IResource, IResource>	mapping;
 
@@ -50,9 +67,21 @@ public class RequestResourceMapping implements IRequestResourceMapping {
 		return resource instanceof RequestResource;
 	}
 
+	/**
+	 * Map requested {@link RequestResource} to a physical {@link IResource}. Additionally, if the second parameter is a {@link IRootResource}
+	 * instance, it creates same slices units and ranges in the request resource slice.
+	 * 
+	 */
 	@Override
 	public void defineMapping(IResource requestResource, IResource rootResource) {
 		mapping.put(requestResource, rootResource);
+
+		if (rootResource instanceof IRootResource && SliceableResource.isSliceable(serviceProvider, rootResource))
+			try {
+				inheriteSliceInformation(requestResource, rootResource);
+			} catch (CapabilityNotFoundException e) {
+				log.warn("Could not automatically create slice units on virtual resource. Process should be manually done.");
+			}
 	}
 
 	@Override
@@ -77,6 +106,30 @@ public class RequestResourceMapping implements IRequestResourceMapping {
 
 	@Override
 	public void deactivate() {
+	}
+
+	private void inheriteSliceInformation(IResource requestResource, IResource rootResource) throws CapabilityNotFoundException {
+		Slice srcSlice = new Slice(getSlice(rootResource), serviceProvider);
+		Slice dstSlice = new Slice(getSlice(requestResource), serviceProvider);
+
+		for (Unit srcUnit : srcSlice.getUnits()) {
+			Unit dstUnit = dstSlice.addUnit(srcUnit.getName());
+			dstUnit.setRange(srcUnit.getRange());
+		}
+
+	}
+
+	/**
+	 * Returns the {@link SliceResource} provided by a specific {@link IResource}
+	 * 
+	 * @param resource
+	 *            Resource containing the slice to be retrieved.
+	 * @return The {@link SliceResource} instance of the specified <literal>resource</literal>.
+	 * @throws CapabilityNotFoundException
+	 *             If the resource have not bound {@link ISliceProvider} capability.
+	 */
+	private IResource getSlice(IResource resource) throws CapabilityNotFoundException {
+		return serviceProvider.getCapability(resource, ISliceProvider.class).getSlice();
 	}
 
 }

--- a/extensions/network/network.impl/src/test/java/org/mqnaas/network/impl/NetworkManagementTest.java
+++ b/extensions/network/network.impl/src/test/java/org/mqnaas/network/impl/NetworkManagementTest.java
@@ -36,6 +36,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.AdditionalMatchers;
 import org.mockito.Mockito;
 import org.mqnaas.core.api.Endpoint;
@@ -63,6 +64,7 @@ import org.mqnaas.core.impl.RootResource;
 import org.mqnaas.core.impl.slicing.Slice;
 import org.mqnaas.core.impl.slicing.SliceAdministration;
 import org.mqnaas.core.impl.slicing.SliceProvider;
+import org.mqnaas.core.impl.slicing.SliceableResource;
 import org.mqnaas.core.impl.slicing.UnitAdministration;
 import org.mqnaas.core.impl.slicing.UnitManagment;
 import org.mqnaas.core.impl.slicing.UnitResource;
@@ -91,7 +93,11 @@ import org.mqnaas.network.impl.topology.port.NetworkPortManagement;
 import org.mqnaas.network.impl.topology.port.PortManagement;
 import org.mqnaas.network.impl.topology.port.PortResource;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({ SliceableResource.class })
 public class NetworkManagementTest {
 
 	private NetworkManagement		networkManagementCapab;
@@ -462,6 +468,11 @@ public class NetworkManagementTest {
 	public void delegateToSubnetworkTest() throws InstantiationException, IllegalAccessException, CapabilityNotFoundException,
 			ApplicationActivationException, SecurityException, NoSuchMethodException, IllegalArgumentException, InvocationTargetException,
 			URISyntaxException, NetworkCreationException {
+
+		// we have to mock this method. We are not able to inject service provider on capabilities of resources created by the implementation
+		// dinamically, so it would be always null (and launch a NullPointer) on capabilities implementations.
+		PowerMockito.mockStatic(SliceableResource.class);
+		PowerMockito.when(SliceableResource.isSliceable(Mockito.isNull(IServiceProvider.class), Mockito.any(IResource.class))).thenReturn(false);
 
 		// created fake network that "would be created" by the subnetwork
 		IRootResource createdSubnet = new RootResource(RootResourceDescriptor.create(new Specification(Type.NETWORK, "virtual")));

--- a/extensions/network/network.impl/src/test/java/org/mqnaas/network/impl/RequestResourceMappingTest.java
+++ b/extensions/network/network.impl/src/test/java/org/mqnaas/network/impl/RequestResourceMappingTest.java
@@ -1,0 +1,190 @@
+package org.mqnaas.network.impl;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Arrays;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.AdditionalMatchers;
+import org.mockito.Mockito;
+import org.mqnaas.core.api.Endpoint;
+import org.mqnaas.core.api.IResource;
+import org.mqnaas.core.api.IRootResource;
+import org.mqnaas.core.api.IServiceProvider;
+import org.mqnaas.core.api.RootResourceDescriptor;
+import org.mqnaas.core.api.Specification;
+import org.mqnaas.core.api.Specification.Type;
+import org.mqnaas.core.api.exceptions.ApplicationActivationException;
+import org.mqnaas.core.api.exceptions.CapabilityNotFoundException;
+import org.mqnaas.core.api.slicing.ISliceProvider;
+import org.mqnaas.core.api.slicing.ISlicingCapability;
+import org.mqnaas.core.api.slicing.IUnitAdministration;
+import org.mqnaas.core.api.slicing.IUnitManagement;
+import org.mqnaas.core.api.slicing.Range;
+import org.mqnaas.core.impl.RootResource;
+import org.mqnaas.core.impl.slicing.SliceResource;
+import org.mqnaas.core.impl.slicing.UnitAdministration;
+import org.mqnaas.core.impl.slicing.UnitManagment;
+import org.mqnaas.core.impl.slicing.UnitResource;
+import org.mqnaas.general.test.helpers.reflection.ReflectionTestHelper;
+import org.mqnaas.network.api.request.IRequestResourceMapping;
+import org.mqnaas.network.impl.request.RequestResource;
+import org.mqnaas.network.impl.request.RequestResourceMapping;
+import org.powermock.api.mockito.PowerMockito;
+
+/**
+ * 
+ * @author Adrian Rosello Rey (i2CAT)
+ *
+ */
+public class RequestResourceMappingTest {
+
+	private static final String	PORT_UNIT_NAME	= "port";
+	private static final String	VLAN_UNIT_NAME	= "vlan";
+
+	IRequestResourceMapping		requestResourceMapping;
+
+	IServiceProvider			serviceProvider;
+
+	RequestResource				request;
+	IRootResource				rootResource;
+
+	@Before
+	public void prepareTest() throws InstantiationException, IllegalAccessException, URISyntaxException, ApplicationActivationException {
+
+		Endpoint endpoint = new Endpoint(new URI("http://www.myfakeresource.com"));
+		rootResource = new RootResource(RootResourceDescriptor.create(new Specification(Type.OF_SWITCH), Arrays.asList(endpoint)));
+
+		request = new RequestResource();
+
+		requestResourceMapping = new RequestResourceMapping();
+		requestResourceMapping.activate();
+
+		serviceProvider = PowerMockito.mock(IServiceProvider.class);
+		ReflectionTestHelper.injectPrivateField(requestResourceMapping, serviceProvider, "serviceProvider");
+
+	}
+
+	@Test
+	public void isSupportingTest() {
+		Assert.assertTrue("RequestResourceMapping capability should bind to RequestResource instances.", RequestResourceMapping.isSupporting(request));
+		Assert.assertFalse("RequestResourceMapping capability should only bind to RequestResource instances.",
+				RequestResourceMapping.isSupporting(rootResource));
+
+		Assert.assertFalse("RequestResourceMapping capability should only bind to RequestResource instances.",
+				RequestResourceMapping.isSupporting(new IResource() {
+					@Override
+					public String getId() {
+						// TODO Auto-generated method stub
+						return null;
+					}
+				}));
+
+	}
+
+	@Test
+	public void defineMappingTest() throws CapabilityNotFoundException, SecurityException, IllegalArgumentException, IllegalAccessException,
+			ApplicationActivationException {
+
+		// 1) create mock SliceProviders and mock service provider to return them
+		ISliceProvider rootResourceSliceProvider = PowerMockito.mock(ISliceProvider.class);
+		ISliceProvider reqSliceProvider = PowerMockito.mock(ISliceProvider.class);
+
+		PowerMockito.when(serviceProvider.getCapability(Mockito.eq(rootResource), Mockito.eq(ISliceProvider.class))).thenReturn(
+				rootResourceSliceProvider);
+		PowerMockito.when(serviceProvider.getCapability(Mockito.eq(request), Mockito.eq(ISliceProvider.class))).thenReturn(reqSliceProvider);
+
+		// 2) create slice resources
+		IResource rootResourceSlice = new SliceResource();
+		IResource reqSlice = new SliceResource();
+
+		// 3) mock sliceProviders capabilities to return sliced resources
+		PowerMockito.when(rootResourceSliceProvider.getSlice()).thenReturn(rootResourceSlice);
+		PowerMockito.when(reqSliceProvider.getSlice()).thenReturn(reqSlice);
+
+		// 4) create unit management capabilities and mock service provider to return them
+		IUnitManagement reqUnitMgmt = new UnitManagment();
+		IUnitManagement rootResourceUnitMgmt = new UnitManagment();
+		ReflectionTestHelper.injectPrivateField(reqUnitMgmt, new dummyResource(), "resource");
+		ReflectionTestHelper.injectPrivateField(rootResourceUnitMgmt, new dummyResource(), "resource");
+		reqUnitMgmt.activate();
+		rootResourceUnitMgmt.activate();
+		IResource portUnit = rootResourceUnitMgmt.createUnit(PORT_UNIT_NAME);
+		IResource vlanUnit = rootResourceUnitMgmt.createUnit(VLAN_UNIT_NAME);
+
+		PowerMockito.when(serviceProvider.getCapability(Mockito.eq(reqSlice), Mockito.eq(IUnitManagement.class))).thenReturn(reqUnitMgmt);
+		PowerMockito.when(serviceProvider.getCapability(Mockito.eq(rootResourceSlice), Mockito.eq(IUnitManagement.class))).thenReturn(
+				rootResourceUnitMgmt);
+
+		// 5)) create unit administrations and mock service provider to return them
+		IUnitAdministration rootResourcePortAdmin = new UnitAdministration();
+		ReflectionTestHelper.injectPrivateField(rootResourcePortAdmin, new dummyResource(), "resource");
+		rootResourcePortAdmin.activate();
+		rootResourcePortAdmin.setRange(new Range(0, 2));
+
+		IUnitAdministration rootResourceVlanAdmin = new UnitAdministration();
+		ReflectionTestHelper.injectPrivateField(rootResourceVlanAdmin, new dummyResource(), "resource");
+		rootResourceVlanAdmin.activate();
+		rootResourceVlanAdmin.setRange(new Range(0, 4095));
+
+		IUnitAdministration reqVlanAdmin = new UnitAdministration();
+		ReflectionTestHelper.injectPrivateField(reqVlanAdmin, new dummyResource(), "resource");
+		reqVlanAdmin.activate();
+
+		IUnitAdministration reqPortAdmin = new UnitAdministration();
+		ReflectionTestHelper.injectPrivateField(reqPortAdmin, new dummyResource(), "resource");
+		reqPortAdmin.activate();
+
+		PowerMockito.when(serviceProvider.getCapability(Mockito.eq(portUnit), Mockito.eq(IUnitAdministration.class))).thenReturn(
+				rootResourceVlanAdmin);
+		PowerMockito.when(serviceProvider.getCapability(Mockito.eq(vlanUnit), Mockito.eq(IUnitAdministration.class))).thenReturn(
+				rootResourcePortAdmin);
+		PowerMockito
+				.when(serviceProvider.getCapability(AdditionalMatchers.not(AdditionalMatchers.or(Mockito.eq(portUnit), Mockito.eq(vlanUnit))),
+						Mockito.eq(IUnitAdministration.class))).thenReturn(reqVlanAdmin).thenReturn(reqPortAdmin);
+
+		// 6) mock service provider, so the resource can be seen as sliceable
+		PowerMockito.when(serviceProvider.getCapability(Mockito.any(IResource.class), Mockito.eq(ISlicingCapability.class))).thenReturn(
+				PowerMockito.mock(ISlicingCapability.class));
+
+		// Assert before method execution
+		Assert.assertTrue("Virtual resource should not contain any slicing unit yet.", reqUnitMgmt.getUnits().isEmpty());
+		Assert.assertTrue("Capability should not contain any mapped resource yet.", requestResourceMapping.getMappedDevices().isEmpty());
+		Assert.assertNull("Capability should not contain any mapped resource yet.", requestResourceMapping.getMapping(request));
+
+		// METHOD TESTED
+		requestResourceMapping.defineMapping(request, rootResource);
+
+		// Asserts after method execution
+		Assert.assertFalse("Capability should  contain one mapped resource.", requestResourceMapping.getMappedDevices().isEmpty());
+		Assert.assertEquals("Capability should contain one mapped resource.", 1, requestResourceMapping.getMappedDevices().size());
+		Assert.assertEquals("Capability should contain one mapped resource.", request, requestResourceMapping.getMappedDevices().iterator()
+				.next());
+		Assert.assertEquals("Capability should contain the mapping of the request resource.", rootResource,
+				requestResourceMapping.getMapping(request));
+
+		Assert.assertFalse("Virtual resource should contain slicing units.", reqUnitMgmt.getUnits().isEmpty());
+		Assert.assertEquals("Virtual resource should contain two slicing units.", 2, reqUnitMgmt.getUnits().size());
+
+		IResource reqPortUnit = (((UnitResource) reqUnitMgmt.getUnits().get(0)).getName() == PORT_UNIT_NAME ? reqUnitMgmt.getUnits().get(0) : reqUnitMgmt
+				.getUnits().get(1));
+		IResource reqVlanUnit = (((UnitResource) reqUnitMgmt.getUnits().get(0)).getName() == VLAN_UNIT_NAME ? reqUnitMgmt.getUnits().get(0) : reqUnitMgmt
+				.getUnits().get(1));
+		Assert.assertFalse("There should port and vlan slicing units in the virtual resource.", reqPortUnit.equals(reqVlanUnit));
+
+		Assert.assertEquals(new Range(0, 2), reqPortAdmin.getRange());
+		Assert.assertEquals(new Range(0, 4095), reqVlanAdmin.getRange());
+
+	}
+
+	private class dummyResource implements IResource {
+
+		@Override
+		public String getId() {
+			return "dummyId";
+		}
+
+	}
+}


### PR DESCRIPTION
For the CONTENT and SODALES projects, it was desired that, when creating a virtual resource from an existing physical one, it automatically contains the slicing units (and ranges) the physical one had.

For example, let's assume we own a physical TSON, which slicing units are lambda, time and vlan. When the user builds a virtual resource from it, he does not want to create the lambda, time, and vlan slicing units in the virtual resource. He wants the new virtual TSON to inherit those slicing units,

This pull request introduces an easy solution for that. In the moment the mapping between the physical resource and the virtual one is done, it automatically inherits its slicing units.

Fixes task: http://jira.i2cat.net/browse/OPENNAAS-1660