### PR TITLE
Feature/openstack support

### DIFF
--- a/core.api/src/main/java/org/mqnaas/core/api/Specification.java
+++ b/core.api/src/main/java/org/mqnaas/core/api/Specification.java
@@ -95,6 +95,10 @@ public class Specification implements Cloneable {
 		 */
 		CLOUD_MANAGER("Cloud-Manager"),
 		/**
+		 * Host
+		 */
+		HOST("Host"),
+		/**
 		 * Other devices
 		 */
 		OTHER("Other");

--- a/extensions/openstack/openstack-impl/pom.xml
+++ b/extensions/openstack/openstack-impl/pom.xml
@@ -15,18 +15,41 @@
 	<description>MQNaaS OpenStack capabilities implementations</description>
 
 	<dependencies>
-		
+
 		<!-- Other Openstack modules -->
 		<dependency>
 			<groupId>org.mqnaas.extensions</groupId>
 			<artifactId>jclouds-client-provider</artifactId>
 		</dependency>
-	
+
 		<!-- MQNaaS modules -->
 		<dependency>
 			<groupId>org.mqnaas</groupId>
 			<artifactId>core.api</artifactId>
 		</dependency>
+
+		<!-- Testing dependencies -->
+		<dependency>
+			<groupId>org.mqnaas</groupId>
+			<artifactId>test-helpers</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.powermock</groupId>
+			<artifactId>powermock-api-mockito</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.powermock</groupId>
+			<artifactId>powermock-module-junit4</artifactId>
+			<scope>test</scope>
+		</dependency>
+
 	</dependencies>
 
 	<build>

--- a/extensions/openstack/openstack-impl/pom.xml
+++ b/extensions/openstack/openstack-impl/pom.xml
@@ -15,6 +15,18 @@
 	<description>MQNaaS OpenStack capabilities implementations</description>
 
 	<dependencies>
+		
+		<!-- Other Openstack modules -->
+		<dependency>
+			<groupId>org.mqnaas.extensions</groupId>
+			<artifactId>jclouds-client-provider</artifactId>
+		</dependency>
+	
+		<!-- MQNaaS modules -->
+		<dependency>
+			<groupId>org.mqnaas</groupId>
+			<artifactId>core.api</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>
@@ -27,6 +39,7 @@
 					<instructions>
 						<Import-Package>*</Import-Package>
 						<Export-Package>
+							org.mqnaas.extensions.openstack.capabilities.impl
 						</Export-Package>
 					</instructions>
 				</configuration>

--- a/extensions/openstack/openstack-impl/src/main/java/org/mqnaas/extensions/openstack/capabilities/impl/OpenstackRootResourceProvider.java
+++ b/extensions/openstack/openstack-impl/src/main/java/org/mqnaas/extensions/openstack/capabilities/impl/OpenstackRootResourceProvider.java
@@ -172,6 +172,9 @@ public class OpenstackRootResourceProvider implements IRootResourceProvider {
 		if (StringUtils.isEmpty(id))
 			throw new IllegalArgumentException("Valid id is required to retrieve specific IRootResource instance.");
 
+		if (vms.get(id) == null)
+			throw new ResourceNotFoundException("No resource found with id: " + id);
+
 		return vms.get(id);
 	}
 

--- a/extensions/openstack/openstack-impl/src/main/java/org/mqnaas/extensions/openstack/capabilities/impl/OpenstackRootResourceProvider.java
+++ b/extensions/openstack/openstack-impl/src/main/java/org/mqnaas/extensions/openstack/capabilities/impl/OpenstackRootResourceProvider.java
@@ -1,0 +1,209 @@
+package org.mqnaas.extensions.openstack.capabilities.impl;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.apache.commons.lang3.StringUtils;
+import org.jclouds.openstack.nova.v2_0.NovaApi;
+import org.jclouds.openstack.nova.v2_0.domain.Server;
+import org.jclouds.openstack.nova.v2_0.features.ServerApi;
+import org.mqnaas.clientprovider.exceptions.EndpointNotFoundException;
+import org.mqnaas.core.api.Endpoint;
+import org.mqnaas.core.api.IAttributeStore;
+import org.mqnaas.core.api.IResourceManagementListener;
+import org.mqnaas.core.api.IRootResource;
+import org.mqnaas.core.api.IRootResourceProvider;
+import org.mqnaas.core.api.IServiceProvider;
+import org.mqnaas.core.api.RootResourceDescriptor;
+import org.mqnaas.core.api.Specification;
+import org.mqnaas.core.api.Specification.Type;
+import org.mqnaas.core.api.annotations.DependingOn;
+import org.mqnaas.core.api.annotations.Resource;
+import org.mqnaas.core.api.credentials.Credentials;
+import org.mqnaas.core.api.exceptions.ApplicationActivationException;
+import org.mqnaas.core.api.exceptions.ApplicationNotFoundException;
+import org.mqnaas.core.api.exceptions.CapabilityNotFoundException;
+import org.mqnaas.core.api.exceptions.ResourceNotFoundException;
+import org.mqnaas.core.impl.RootResource;
+import org.mqnaas.extensions.openstack.jclouds.clientprovider.IJCloudsNovaClientProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.io.Closeables;
+
+/**
+ * <p>
+ * Specific implementation of the {@link IRootResourceProvider} capability for Openstack cloud managers.
+ * </p>
+ * <p>
+ * This capability manages the VMs of Openstack, by creating a {@link IRootResource} instance for each {@link Server} Openstack contains. These
+ * resources are created during activation method, by using the client provided by {@link IJCloudsNovaClientProvider} to communicate with Openstack.
+ * </p>
+ * 
+ * @author Adrian Rosello Rey (i2CAT)
+ *
+ */
+public class OpenstackRootResourceProvider implements IRootResourceProvider {
+
+	private static final Logger			log				= LoggerFactory.getLogger(OpenstackRootResourceProvider.class);
+
+	public static final String			ZONE_ATTRIBUTE	= "zone";
+
+	/**
+	 * Set of Openstack Virtual Machines managed by this capability. Key->resourceId, Value->rootResourceInstance
+	 */
+	private Map<String, IRootResource>	vms;
+
+	private NovaApi						novaClient;
+
+	@DependingOn
+	IResourceManagementListener			resourceManagementListener;
+
+	@DependingOn
+	IJCloudsNovaClientProvider			jcloudsClientProvider;
+
+	@DependingOn
+	IResourceManagementListener			rmListener;
+
+	@DependingOn
+	IServiceProvider					serviceProvider;
+
+	@Resource
+	IRootResource						resource;
+
+	public static boolean isSupporting(IRootResource resource) {
+		Specification resourceSpec = resource.getDescriptor().getSpecification();
+
+		return (resourceSpec.getType().equals(Type.CLOUD_MANAGER) && resourceSpec.getModel().equals("openstack"));
+	}
+
+	@Override
+	public void activate() throws ApplicationActivationException {
+
+		log.info("Initializing OpenstackRootResourceProvider capability for resource " + resource.getId());
+
+		try {
+			novaClient = jcloudsClientProvider.getClient(resource);
+		} catch (EndpointNotFoundException e) {
+			throw new ApplicationActivationException("Could not instantiate JClouds client.", e);
+		}
+
+		try {
+			initializeVms();
+		} catch (Exception e) {
+			throw new ApplicationActivationException("Cloud not initialize Openstack VMs.", e);
+		}
+		log.info("Initialized OpenstackRootResourceProvider capability for resource " + resource.getId());
+
+	}
+
+	@Override
+	public void deactivate() {
+		log.info("Removing OpenstackRootResourceProvider capability from resource " + resource.getId());
+
+		for (IRootResource vm : vms.values())
+			resourceManagementListener.resourceRemoved(vm, this, IRootResourceProvider.class);
+
+		vms.clear();
+
+		try {
+			Closeables.close(novaClient, true);
+		} catch (IOException e) {
+			log.warn("Could not close jclouds nova client.", e);
+		}
+	}
+
+	@Override
+	public List<IRootResource> getRootResources() {
+		log.info("Getting all IRootResources managed by resource " + resource.getId());
+		return new ArrayList<IRootResource>(vms.values());
+	}
+
+	@Override
+	public List<IRootResource> getRootResources(Type type, String model, String version) throws ResourceNotFoundException {
+		log.info("Getting all IRootResources managed by resource " + resource.getId() + " [type= " + type + ", model=" + model + ", version=" + version + "]");
+
+		if (type == null && StringUtils.isEmpty(model) && StringUtils.isEmpty(version)) {
+			log.debug("Filter is null. Returning all IRootResources managed by resource " + resource.getId());
+			return getRootResources();
+		}
+
+		List<IRootResource> resources = new ArrayList<IRootResource>();
+
+		for (IRootResource vm : getRootResources()) {
+			Specification vmSpec = vm.getDescriptor().getSpecification();
+
+			if (vmSpec.getType().equals(type) && vmSpec.getModel().equals(model) && vmSpec.getVersion().equals(version))
+				resources.add(vm);
+		}
+
+		return resources;
+
+	}
+
+	@Override
+	public IRootResource getRootResource(String id) throws ResourceNotFoundException {
+
+		if (StringUtils.isEmpty(id))
+			throw new IllegalArgumentException("Valid id is required to retrieve specific IRootResource instance.");
+
+		return vms.get(id);
+	}
+
+	@Override
+	public void setRootResources(Collection<IRootResource> rootResources) {
+		throw new UnsupportedOperationException("The OpenstackRootResourceProvidder capability does not allow this operation.");
+
+	}
+
+	/**
+	 * Creates {@link IRootResource}s for each {@link Server} Openstack manages.
+	 */
+	private void initializeVms() throws InstantiationException, IllegalAccessException, CapabilityNotFoundException, ApplicationNotFoundException {
+
+		vms = new ConcurrentHashMap<String, IRootResource>();
+
+		for (String zone : novaClient.getConfiguredZones()) {
+			log.debug("Reading Openstack VMs [zone=" + zone + "]");
+
+			ServerApi serverClient = novaClient.getServerApiForZone(zone);
+			for (Server server : serverClient.listInDetail().concat()) {
+
+				IRootResource rootResource = createVmRepresentation();
+				resourceManagementListener.resourceAdded(rootResource, this, IRootResourceProvider.class);
+
+				log.debug("Instantied Openstack VM [MqNaas-id=" + rootResource.getId() + ", Openstack-id=" + server.getId() + "]");
+
+				IAttributeStore attrStore = serviceProvider.getCapability(rootResource, IAttributeStore.class);
+
+				attrStore.setAttribute(ZONE_ATTRIBUTE, zone);
+				attrStore.setAttribute(IAttributeStore.RESOURCE_EXTERNAL_ID, server.getId());
+				attrStore.setAttribute(IAttributeStore.RESOURCE_EXTERNAL_NAME, server.getName());
+
+				vms.put(rootResource.getId(), rootResource);
+			}
+		}
+
+		log.info("Initialized " + vms.size() + " VMs managed by resource " + resource.getId());
+
+	}
+
+	/**
+	 * Instantiates a {@link IRootResource} of {@link Type#HOST} type and "openstack" model. The endpoints of this resource are inherit from the
+	 * resource this capability is bound to, as well as its {@link Credentials}
+	 */
+	private IRootResource createVmRepresentation() throws InstantiationException, IllegalAccessException {
+
+		Collection<Endpoint> openstackEndpoints = new ArrayList<Endpoint>(resource.getDescriptor().getEndpoints());
+		Specification resourceSpec = new Specification(Type.HOST, "openstack");
+
+		IRootResource vm = new RootResource(RootResourceDescriptor.create(resourceSpec, openstackEndpoints));
+		vm.getDescriptor().setCredentials(resource.getDescriptor().getCredentials());
+
+		return vm;
+	}
+}

--- a/extensions/openstack/openstack-impl/src/main/java/org/mqnaas/extensions/openstack/capabilities/impl/OpenstackRootResourceProvider.java
+++ b/extensions/openstack/openstack-impl/src/main/java/org/mqnaas/extensions/openstack/capabilities/impl/OpenstackRootResourceProvider.java
@@ -1,5 +1,26 @@
 package org.mqnaas.extensions.openstack.capabilities.impl;
 
+/*
+ * #%L
+ * MQNaaS :: OpenStack Implementation
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i
+ * 			Innovació a Catalunya
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;

--- a/extensions/openstack/openstack-impl/src/test/java/org/mqnaas/extensions/openstack/capabilities/impl/OpenstackRootResourceProviderTest.java
+++ b/extensions/openstack/openstack-impl/src/test/java/org/mqnaas/extensions/openstack/capabilities/impl/OpenstackRootResourceProviderTest.java
@@ -1,0 +1,301 @@
+package org.mqnaas.extensions.openstack.capabilities.impl;
+
+/*
+ * #%L
+ * MQNaaS :: OpenStack Implementation
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i
+ * 			Innovació a Catalunya
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.cxf.common.util.SortedArraySet;
+import org.jclouds.collect.PagedIterable;
+import org.jclouds.openstack.nova.v2_0.NovaApi;
+import org.jclouds.openstack.nova.v2_0.domain.Server;
+import org.jclouds.openstack.nova.v2_0.domain.Server.Status;
+import org.jclouds.openstack.nova.v2_0.features.ServerApi;
+import org.jclouds.openstack.v2_0.domain.Resource;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.mqnaas.clientprovider.exceptions.EndpointNotFoundException;
+import org.mqnaas.core.api.Endpoint;
+import org.mqnaas.core.api.IAttributeStore;
+import org.mqnaas.core.api.IResourceManagementListener;
+import org.mqnaas.core.api.IRootResource;
+import org.mqnaas.core.api.IRootResourceProvider;
+import org.mqnaas.core.api.IServiceProvider;
+import org.mqnaas.core.api.RootResourceDescriptor;
+import org.mqnaas.core.api.Specification;
+import org.mqnaas.core.api.Specification.Type;
+import org.mqnaas.core.api.credentials.Credentials;
+import org.mqnaas.core.api.credentials.UsernamePasswordTenantCredentials;
+import org.mqnaas.core.api.exceptions.ApplicationActivationException;
+import org.mqnaas.core.api.exceptions.CapabilityNotFoundException;
+import org.mqnaas.core.impl.AttributeStore;
+import org.mqnaas.core.impl.RootResource;
+import org.mqnaas.extensions.openstack.jclouds.clientprovider.IJCloudsNovaClientProvider;
+import org.mqnaas.general.test.helpers.reflection.ReflectionTestHelper;
+import org.powermock.api.mockito.PowerMockito;
+
+import com.google.common.collect.FluentIterable;
+
+/**
+ * <p>
+ * Class containing tests for the {@link OpenstackRootResourceProvider} capability implementation.
+ * </p>
+ * 
+ * @author Adrian Rosello Rey (i2CAT)
+ *
+ */
+public class OpenstackRootResourceProviderTest {
+
+	// used to create the endpoint of the resource the capability is bound to.
+	private static final String	RESOURCE_URI		= "http://www.myfakeresource.com/";
+	// user to create credentials of the ersource the capability is bound to.
+	private final static String	PASSWORD			= "1234";
+
+	// constants user to create the mocked client response
+	private final static String	ZONE_A				= "RegionOne";
+	private final static String	ZONE_B				= "RegionTwo";
+
+	private final static String	SERVER_ONE_ID		= "23424-234346-13";
+	private final static String	SERVER_TWO_ID		= "76878-123323-54";
+	private final static String	SERVER_THREE_ID		= "54353-742572-37";
+
+	private final static String	SERVER_ONE_NAME		= "server1";
+	private final static String	SERVER_TWO_NAME		= "server2";
+	private final static String	SERVER_THREE_NAME	= "server3";
+
+	// required by JClouds to build "server" object
+	private static final String	TENANT_ID			= "tenant-1234";
+	private static final String	USER_ID				= "user-1234";
+
+	/**
+	 * AttributeStores capabilities for the VMs returned by mocked service provider
+	 */
+	IAttributeStore				attributeStoreServerOne;
+	IAttributeStore				attributeStoreServerTwo;
+	IAttributeStore				attributeStoreServerThree;
+	/**
+	 * Resource injected in capability.
+	 */
+	IRootResource				openstackResource;
+
+	/**
+	 * Capability to be tested
+	 */
+	IRootResourceProvider		openstackRootResourceProvider;
+
+	/**
+	 * All capabilities dependencies (will be mocked)
+	 */
+	IServiceProvider			mockedServiceProvider;
+	IJCloudsNovaClientProvider	mockedJcloudsClientProvider;
+	NovaApi						mockedNovaApi;
+
+	@Before
+	public void prepareTest() throws EndpointNotFoundException, SecurityException, IllegalArgumentException, IllegalAccessException,
+			CapabilityNotFoundException, InstantiationException, URISyntaxException {
+		openstackRootResourceProvider = new OpenstackRootResourceProvider();
+		mockCapabilityDependencies();
+	}
+
+	/**
+	 * Tests the {@link OpenstackRootResourceProvider#activate()} method, which instantiates the {@link IRootResource}s representing the Openstack
+	 * VMs. Client simulates Openstack contains three {@link Server}s in two different zones, so 3 IRootResources should be created,containing its
+	 * metadata in {@link IAttributeStore} capability
+	 */
+	@Test
+	public void activateTest() throws ApplicationActivationException, CapabilityNotFoundException {
+
+		openstackRootResourceProvider.activate();
+		List<IRootResource> vms = openstackRootResourceProvider.getRootResources();
+
+		Assert.assertNotNull("OpenstackRootResourceProvider capability should contain virtual machines.", vms);
+		Assert.assertFalse("OpenstackRootResourceProvider capability should contain virtual machines.", vms.isEmpty());
+		Assert.assertEquals("OpenstackRootResourceProvider capability should contain virtual machines.", 3, vms.size());
+
+		IRootResource rootResourceOne = vms.get(0);
+		IRootResource rootResourceTwo = vms.get(1);
+		IRootResource rootResourceThree = vms.get(2);
+
+		checkResourceSpecification(rootResourceOne);
+		checkResourceSpecification(rootResourceTwo);
+		checkResourceSpecification(rootResourceThree);
+
+		checkResouceAttributeStore(attributeStoreServerOne, SERVER_ONE_ID, SERVER_ONE_NAME, ZONE_A);
+		checkResouceAttributeStore(attributeStoreServerTwo, SERVER_TWO_ID, SERVER_TWO_NAME, ZONE_A);
+		checkResouceAttributeStore(attributeStoreServerThree, SERVER_THREE_ID, SERVER_THREE_NAME, ZONE_B);
+
+	}
+
+	/**
+	 * Checks that the {@link IAttributeStore} capability of a specific openstack VM representation contains the external id, name and zone it belongs
+	 * to.
+	 */
+	private void checkResouceAttributeStore(IAttributeStore resourceAttributeStore, String serverId, String serverName, String zone) {
+
+		Assert.assertNotNull("AttributeStore should contain the external id of VM resource.",
+				resourceAttributeStore.getAttribute(IAttributeStore.RESOURCE_EXTERNAL_ID));
+		Assert.assertEquals("VM representation should contain the externalId " + serverId,
+				resourceAttributeStore.getAttribute(IAttributeStore.RESOURCE_EXTERNAL_ID), serverId);
+
+		Assert.assertNotNull("AttributeStore should contain the external name of VM resource.",
+				resourceAttributeStore.getAttribute(IAttributeStore.RESOURCE_EXTERNAL_NAME));
+		Assert.assertEquals("VM representation should contain the externalName " + serverName,
+				resourceAttributeStore.getAttribute(IAttributeStore.RESOURCE_EXTERNAL_NAME), serverName);
+
+		Assert.assertNotNull("AttributeStore should contain the zone the VM resource belongs to.",
+				resourceAttributeStore.getAttribute(OpenstackRootResourceProvider.ZONE_ATTRIBUTE));
+
+		Assert.assertEquals("VM representation should belong to zone " + zone,
+				resourceAttributeStore.getAttribute(OpenstackRootResourceProvider.ZONE_ATTRIBUTE), zone);
+	}
+
+	/**
+	 * Checks that the given {@link IRootResource}, representing an Openstack VM, contains correct {@link Specification}, and that its
+	 * {@link Credentials} and {@link Endpoint}s have been inherited from parent resource.
+	 */
+	private void checkResourceSpecification(IRootResource rootResource) {
+
+		Assert.assertNotNull("VM Resource representation should contain a descriptor.", rootResource.getDescriptor());
+		Assert.assertNotNull("VM Resource representation should contain a descriptor", rootResource.getDescriptor().getSpecification());
+
+		Assert.assertEquals("VM Resource representation should be of type host.", Type.HOST, rootResource.getDescriptor().getSpecification()
+				.getType());
+		Assert.assertEquals("VM Resource representation should be of model \"openstack\".", "openstack", rootResource.getDescriptor()
+				.getSpecification().getModel());
+
+		Assert.assertNotNull("VM Resource representation should contain a list of endpoints", rootResource.getDescriptor().getEndpoints());
+		Assert.assertEquals("VM Resource representation should inherit endpoints from parent resource.", openstackResource.getDescriptor()
+				.getEndpoints(), rootResource.getDescriptor().getEndpoints());
+
+		Assert.assertEquals("VM Resource representation should inherit credentials from parent resource.", openstackResource.getDescriptor()
+				.getCredentials(), rootResource.getDescriptor().getCredentials());
+
+	}
+
+	/**
+	 * Mock and inject required capabilities and resources in the tested capability.
+	 */
+	private void mockCapabilityDependencies() throws EndpointNotFoundException, SecurityException, IllegalArgumentException, IllegalAccessException,
+			CapabilityNotFoundException, InstantiationException, URISyntaxException {
+
+		// create and inject resource in capability
+
+		Specification spec = new Specification(Type.CLOUD_MANAGER, "openstack");
+		Endpoint fakeEndpoint = new Endpoint(new URI(RESOURCE_URI));
+		UsernamePasswordTenantCredentials credentials = new UsernamePasswordTenantCredentials(USER_ID, PASSWORD, TENANT_ID);
+
+		openstackResource = new RootResource(RootResourceDescriptor.create(spec, Arrays.asList(fakeEndpoint), credentials));
+		ReflectionTestHelper.injectPrivateField(openstackRootResourceProvider, openstackResource, "resource");
+
+		// mock NovaApi.getConfigurezZones() responses
+		Set<String> zones = new SortedArraySet<String>();
+		zones.add(ZONE_A);
+		zones.add(ZONE_B);
+		mockedNovaApi = PowerMockito.mock(NovaApi.class);
+		PowerMockito.when(mockedNovaApi.getConfiguredZones()).thenReturn(zones);
+
+		// mock NovaApi.getServerAPI for Zone
+		ServerApi serverApiRegionOne = PowerMockito.mock(ServerApi.class);
+		ServerApi serverApiRegionTwo = PowerMockito.mock(ServerApi.class);
+		PowerMockito.when(mockedNovaApi.getServerApiForZone(Mockito.eq(ZONE_A))).thenReturn(serverApiRegionOne);
+		PowerMockito.when(mockedNovaApi.getServerApiForZone(Mockito.eq(ZONE_B))).thenReturn(serverApiRegionTwo);
+
+		Server serverOne = buildServerObject(SERVER_ONE_ID, SERVER_ONE_NAME);
+		Server serverTwo = buildServerObject(SERVER_TWO_ID, SERVER_TWO_NAME);
+		Server serverThree = buildServerObject(SERVER_THREE_ID, SERVER_THREE_NAME);
+
+		PagedIterable<Server> serverApiRegionOneServers = PowerMockito.mock(PagedIterable.class);
+		PagedIterable<Server> serverApiRegionTwoServers = PowerMockito.mock(PagedIterable.class);
+
+		PowerMockito.when(serverApiRegionOne.listInDetail()).thenReturn(serverApiRegionOneServers);
+		PowerMockito.when(serverApiRegionTwo.listInDetail()).thenReturn(serverApiRegionTwoServers);
+
+		PowerMockito.when(serverApiRegionOneServers.concat()).thenReturn(new dummyServerFluentIterable(serverOne, serverTwo));
+		PowerMockito.when(serverApiRegionTwoServers.concat()).thenReturn(new dummyServerFluentIterable(serverThree));
+
+		// mock resourceManagementListener
+		IResourceManagementListener rmListener = PowerMockito.mock(IResourceManagementListener.class);
+		ReflectionTestHelper.injectPrivateField(openstackRootResourceProvider, rmListener, "resourceManagementListener");
+
+		// mock attributeStores
+		attributeStoreServerOne = new AttributeStore();
+		attributeStoreServerTwo = new AttributeStore();
+		attributeStoreServerThree = new AttributeStore();
+		ReflectionTestHelper.injectPrivateField(attributeStoreServerOne, new HashMap<String, String>(), "attributes");
+		ReflectionTestHelper.injectPrivateField(attributeStoreServerTwo, new HashMap<String, String>(), "attributes");
+		ReflectionTestHelper.injectPrivateField(attributeStoreServerThree, new HashMap<String, String>(), "attributes");
+
+		// mock jCloudsClientProvider and inject it in capability.
+		mockedJcloudsClientProvider = PowerMockito.mock(IJCloudsNovaClientProvider.class);
+		PowerMockito.when(mockedJcloudsClientProvider.getClient(Mockito.eq(openstackResource))).thenReturn(mockedNovaApi);
+
+		ReflectionTestHelper.injectPrivateField(openstackRootResourceProvider, mockedJcloudsClientProvider, "jcloudsClientProvider");
+
+		// mock and inject service provider
+
+		IServiceProvider serviceProvider = PowerMockito.mock(IServiceProvider.class);
+		PowerMockito.when(serviceProvider.getCapability(Mockito.any(IRootResource.class), Mockito.eq(IAttributeStore.class)))
+				.thenReturn(attributeStoreServerOne).thenReturn(attributeStoreServerTwo).thenReturn(attributeStoreServerThree);
+		ReflectionTestHelper.injectPrivateField(openstackRootResourceProvider, serviceProvider, "serviceProvider");
+
+	}
+
+	/**
+	 * Builds a {@link Server} instance with the specificed server id and name, and adds all required information by JClouds to build a server
+	 * instance.
+	 */
+	private Server buildServerObject(String serverId, String serverName) {
+		return Server.builder().id(serverId).name(serverName).tenantId(TENANT_ID).userId(USER_ID)
+				.created(new Date(System.currentTimeMillis())).status(Status.ACTIVE).flavor(PowerMockito.mock(Resource.class)).build();
+	}
+
+	/**
+	 * Dummy implementation of the {@link FluentIterable} abstract class. This abstract belongs to JClouds client and its used to iterate over
+	 * Resources. This implementation is for testing purposes and contains a list of {@link Server}s.
+	 * 
+	 * @author Adrian Rosello Rey (i2CAT)
+	 *
+	 */
+	private class dummyServerFluentIterable extends FluentIterable<Server> {
+
+		List<Server>	servers;
+
+		public dummyServerFluentIterable(Server... server) {
+			servers = Arrays.asList(server);
+		}
+
+		@Override
+		public Iterator iterator() {
+			return servers.iterator();
+		}
+
+	}
+
+}

--- a/extensions/openstack/src/main/resources/features.xml
+++ b/extensions/openstack/src/main/resources/features.xml
@@ -2,8 +2,11 @@
 <features xmlns="http://karaf.apache.org/xmlns/features/v1.0.0">
 
 	<repository>mvn:org.apache.jclouds.karaf/jclouds-karaf/${jclouds.version}/xml/features</repository>
+	<!-- MQNaaS repository -->
+	<repository>mvn:org.mqnaas/mqnaas/${mqnaas.version}/xml/features</repository>
 
 	<feature name="mqnaas-openstack" version="${project.version}">
+		<feature version="${mqnaas.version}">mqnaas</feature>
 		<feature version="${project.version}">mqnaas-jclouds</feature>
 
 		<bundle>mvn:org.mqnaas.extensions/jclouds-client-provider/${project.version}</bundle>


### PR DESCRIPTION
This pull erquest introduces the IRootResourceProvider implementation for the Openstack Cloud-Manager resource.

Support for creating IRootResources of type Cloud-manager was already provided in pull request https://github.com/dana-i2cat/mqnaas/pull/205. Now the ones matching "openstack" model would contain to this new capability.

The OpenstackRootResourceProvider capability manages, for the moment, the VMs of the Openstack instance it represents. Therefore, it uses JClouds client to get a list of all existing VMs, and create a IRootResource of type "host" and model "openstack" for each of them.

Fixes: [CON-173](http://jira.i2cat.net/browse/CON-173), [CON-174](http://jira.i2cat.net/browse/CON-174)
