### PR TITLE
Feature/openstack-support

### DIFF
--- a/extensions/openstack/openstack-api/pom.xml
+++ b/extensions/openstack/openstack-api/pom.xml
@@ -15,6 +15,11 @@
 	<description>OpenStack Capabilities APIs and models</description>
 	
 	<dependencies>
+		<!-- MQNaaS dependencies -->
+		<dependency>
+			<groupId>org.mqnaas</groupId>
+			<artifactId>core.api</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>
@@ -27,6 +32,7 @@
 					<instructions>
 						<Import-Package>*</Import-Package>
 						<Export-Package>
+							org.mqnaas.extensions.openstack.capabilities.host.api
 						</Export-Package>
 					</instructions>
 				</configuration>

--- a/extensions/openstack/openstack-api/src/main/java/org/mqnaas/extensions/openstack/capabilities/host/api/IHostAdministration.java
+++ b/extensions/openstack/openstack-api/src/main/java/org/mqnaas/extensions/openstack/capabilities/host/api/IHostAdministration.java
@@ -43,12 +43,12 @@ public interface IHostAdministration extends ICapability {
 	/**
 	 * Returns the host amount of memory in MB.
 	 */
-	float getMemorySize();
+	int getMemorySize();
 
 	/**
 	 * Returns the Disk size in GB.
 	 */
-	float getDiskSize();
+	int getDiskSize();
 
 	/**
 	 * Returns the size of the Swap partition.

--- a/extensions/openstack/openstack-api/src/main/java/org/mqnaas/extensions/openstack/capabilities/host/api/IHostAdministration.java
+++ b/extensions/openstack/openstack-api/src/main/java/org/mqnaas/extensions/openstack/capabilities/host/api/IHostAdministration.java
@@ -1,0 +1,58 @@
+package org.mqnaas.extensions.openstack.capabilities.host.api;
+
+/*
+ * #%L
+ * MQNaaS :: OpenStack API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i
+ * 			Innovació a Catalunya
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import org.mqnaas.core.api.ICapability;
+import org.mqnaas.core.api.IRootResource;
+import org.mqnaas.core.api.Specification.Type;
+
+/**
+ * <p>
+ * Capability providing services to set and retrieve the main hardware attributes of a {@link Type#HOST} {@link IRootResource}
+ * </p>
+ * 
+ * @author Adrian Rosello Rey (i2CAT)
+ * 
+ */
+public interface IHostAdministration extends ICapability {
+
+	/**
+	 * Returns the number of virtual CPUs of the host.
+	 */
+	int getNumberOfCpus();
+
+	/**
+	 * Returns the host amount of memory in MB.
+	 */
+	float getMemorySize();
+
+	/**
+	 * Returns the Disk size in GB.
+	 */
+	float getDiskSize();
+
+	/**
+	 * Returns the size of the Swap partition.
+	 */
+	String getSwapSize();
+
+}

--- a/extensions/openstack/openstack-impl/pom.xml
+++ b/extensions/openstack/openstack-impl/pom.xml
@@ -21,6 +21,10 @@
 			<groupId>org.mqnaas.extensions</groupId>
 			<artifactId>jclouds-client-provider</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.mqnaas.extensions</groupId>
+			<artifactId>openstack-api</artifactId>
+		</dependency>
 
 		<!-- MQNaaS modules -->
 		<dependency>

--- a/extensions/openstack/openstack-impl/src/main/java/org/mqnaas/extensions/openstack/capabilities/impl/OpenstackHostAdministration.java
+++ b/extensions/openstack/openstack-impl/src/main/java/org/mqnaas/extensions/openstack/capabilities/impl/OpenstackHostAdministration.java
@@ -1,5 +1,26 @@
 package org.mqnaas.extensions.openstack.capabilities.impl;
 
+/*
+ * #%L
+ * MQNaaS :: OpenStack Implementation
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i
+ * 			Innovació a Catalunya
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import java.io.IOException;
 
 import org.apache.commons.lang3.StringUtils;
@@ -95,7 +116,7 @@ public class OpenstackHostAdministration implements IHostAdministration {
 	}
 
 	@Override
-	public float getMemorySize() {
+	public int getMemorySize() {
 		log.debug("Getting memory size of host [id=" + resource.getId() + "]");
 
 		Server server = getServer();
@@ -105,7 +126,7 @@ public class OpenstackHostAdministration implements IHostAdministration {
 	}
 
 	@Override
-	public float getDiskSize() {
+	public int getDiskSize() {
 		log.debug("Getting disk size of host [id=" + resource.getId() + "]");
 
 		Server server = getServer();

--- a/extensions/openstack/openstack-impl/src/main/java/org/mqnaas/extensions/openstack/capabilities/impl/OpenstackHostAdministration.java
+++ b/extensions/openstack/openstack-impl/src/main/java/org/mqnaas/extensions/openstack/capabilities/impl/OpenstackHostAdministration.java
@@ -1,0 +1,157 @@
+package org.mqnaas.extensions.openstack.capabilities.impl;
+
+import java.io.IOException;
+
+import org.apache.commons.lang3.StringUtils;
+import org.jclouds.openstack.nova.v2_0.NovaApi;
+import org.jclouds.openstack.nova.v2_0.domain.Flavor;
+import org.jclouds.openstack.nova.v2_0.domain.Server;
+import org.jclouds.openstack.nova.v2_0.features.ServerApi;
+import org.mqnaas.clientprovider.exceptions.EndpointNotFoundException;
+import org.mqnaas.core.api.IAttributeStore;
+import org.mqnaas.core.api.IRootResource;
+import org.mqnaas.core.api.Specification;
+import org.mqnaas.core.api.Specification.Type;
+import org.mqnaas.core.api.annotations.DependingOn;
+import org.mqnaas.core.api.annotations.Resource;
+import org.mqnaas.core.api.exceptions.ApplicationActivationException;
+import org.mqnaas.extensions.openstack.capabilities.host.api.IHostAdministration;
+import org.mqnaas.extensions.openstack.jclouds.clientprovider.IJCloudsNovaClientProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.io.Closeables;
+
+/**
+ * <p>
+ * Specific implementation of the {@link IHostAdministration} capability for Openstack virtual machines.
+ * </p>
+ * 
+ * <p>
+ * This capability does not store any information about the {@link Server}. Every getter method uses the Jclouds client in order to retrieve this
+ * information from OpenStack.
+ * </p>
+ * 
+ * @author Adrian Rosello Rey (i2CAT)
+ * 
+ */
+public class OpenstackHostAdministration implements IHostAdministration {
+
+	private static final Logger	log	= LoggerFactory.getLogger(OpenstackHostAdministration.class);
+
+	private NovaApi				novaClient;
+
+	@DependingOn
+	IAttributeStore				attributeStore;
+
+	@DependingOn
+	IJCloudsNovaClientProvider	jcloudsClientProvider;
+
+	@Resource
+	IRootResource				resource;
+
+	public static boolean isSupporting(IRootResource resource) {
+		Specification resourceSpec = resource.getDescriptor().getSpecification();
+
+		return (resourceSpec.getType().equals(Type.HOST) && resourceSpec.getModel().equals("openstack"));
+	}
+
+	@Override
+	public void activate() throws ApplicationActivationException {
+		log.info("Initializing OpenstackHostAdministration capability for resource " + resource.getId());
+
+		try {
+			novaClient = jcloudsClientProvider.getClient(resource);
+		} catch (EndpointNotFoundException e) {
+			throw new ApplicationActivationException("Could not instantiate JClouds client.", e);
+		}
+
+		log.info("Initialized OpenstackHostAdministration capability for resource " + resource.getId());
+
+	}
+
+	@Override
+	public void deactivate() {
+		log.info("Removing OpenstackHostAdministration capability from resource " + resource.getId());
+
+		try {
+			Closeables.close(novaClient, true);
+		} catch (IOException e) {
+			log.warn("Could not close jclouds nova client.", e);
+		}
+
+		log.info("Removed OpenstackHostAdministration capability from resource " + resource.getId());
+
+	}
+
+	@Override
+	public int getNumberOfCpus() {
+		log.debug("Getting number of cpus of host [id=" + resource.getId() + "]");
+
+		Server server = getServer();
+		Flavor flavor = (Flavor) server.getFlavor();
+
+		return flavor.getVcpus();
+	}
+
+	@Override
+	public float getMemorySize() {
+		log.debug("Getting memory size of host [id=" + resource.getId() + "]");
+
+		Server server = getServer();
+		Flavor flavor = (Flavor) server.getFlavor();
+
+		return flavor.getRam();
+	}
+
+	@Override
+	public float getDiskSize() {
+		log.debug("Getting disk size of host [id=" + resource.getId() + "]");
+
+		Server server = getServer();
+		Flavor flavor = (Flavor) server.getFlavor();
+
+		return flavor.getDisk();
+	}
+
+	@Override
+	public String getSwapSize() {
+
+		Server server = getServer();
+		Flavor flavor = (Flavor) server.getFlavor();
+
+		return flavor.getSwap() != null ? flavor.getSwap().get() : null;
+	}
+
+	/**
+	 * Retrieves the {@link Server} instance represented by the injected <code>resource</code> by using the jclouds client.
+	 * 
+	 * @throws IllegalStateException
+	 *             <ul>
+	 *             <li>If {@link IAttributeStore} capability of the injected resource does not contain information about the {@link Server} id and the
+	 *             zone it belongs to.</li>
+	 *             <li>If there's no zone identified by the zoneId stored in IAttributeStore capability.</li>
+	 *             <li>If there's no server identified by the id stored in IAttributeStore capability.</li>
+	 *             </ul>
+	 */
+	private Server getServer() {
+
+		String zone = attributeStore.getAttribute(OpenstackRootResourceProvider.ZONE_ATTRIBUTE);
+		String vmId = attributeStore.getAttribute(IAttributeStore.RESOURCE_EXTERNAL_ID);
+
+		if (StringUtils.isEmpty(zone) || StringUtils.isEmpty(vmId))
+			throw new IllegalStateException("Can't read VM cpus if AttributeStore does not contain its external id and the zone it belongs to.");
+
+		ServerApi serverClient = novaClient.getServerApiForZone(zone);
+
+		if (serverClient == null)
+			throw new IllegalStateException("There's no configured zone with such id [zone=" + zone + "]");
+
+		Server server = serverClient.get(vmId);
+		if (server == null)
+			throw new IllegalStateException("There's no server with such id in this zone [serverId=" + vmId + ", zone=" + zone + "]");
+
+		return server;
+	}
+
+}

--- a/extensions/openstack/openstack-impl/src/test/java/org/mqnaas/extensions/openstack/capabilities/impl/OpenstackHostAdministrationTest.java
+++ b/extensions/openstack/openstack-impl/src/test/java/org/mqnaas/extensions/openstack/capabilities/impl/OpenstackHostAdministrationTest.java
@@ -1,0 +1,219 @@
+package org.mqnaas.extensions.openstack.capabilities.impl;
+
+/*
+ * #%L
+ * MQNaaS :: OpenStack Implementation
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i
+ * 			Innovació a Catalunya
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashMap;
+
+import org.jclouds.openstack.nova.v2_0.NovaApi;
+import org.jclouds.openstack.nova.v2_0.domain.Flavor;
+import org.jclouds.openstack.nova.v2_0.domain.Server;
+import org.jclouds.openstack.nova.v2_0.domain.Server.Status;
+import org.jclouds.openstack.nova.v2_0.features.ServerApi;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.mqnaas.clientprovider.exceptions.EndpointNotFoundException;
+import org.mqnaas.core.api.Endpoint;
+import org.mqnaas.core.api.IAttributeStore;
+import org.mqnaas.core.api.IRootResource;
+import org.mqnaas.core.api.IServiceProvider;
+import org.mqnaas.core.api.RootResourceDescriptor;
+import org.mqnaas.core.api.Specification;
+import org.mqnaas.core.api.Specification.Type;
+import org.mqnaas.core.api.credentials.UsernamePasswordTenantCredentials;
+import org.mqnaas.core.api.exceptions.ApplicationActivationException;
+import org.mqnaas.core.impl.AttributeStore;
+import org.mqnaas.core.impl.RootResource;
+import org.mqnaas.extensions.openstack.capabilities.host.api.IHostAdministration;
+import org.mqnaas.extensions.openstack.jclouds.clientprovider.IJCloudsNovaClientProvider;
+import org.mqnaas.general.test.helpers.reflection.ReflectionTestHelper;
+import org.powermock.api.mockito.PowerMockito;
+
+/**
+ * <p>
+ * Unitary tests for the {@link OpenstackHostAdministration} capability.
+ * </p>
+ * 
+ * @author Adrian Rosello Rey (i2CAT)
+ *
+ */
+public class OpenstackHostAdministrationTest {
+
+	// used to create the endpoint of the resource the capability is bound to.
+	private static final String	RESOURCE_URI	= "http://www.myfakeresource.com/";
+
+	// required to jclouds clientprovider to instantiate client.
+	private static final String	TENANT_ID		= "tenant-1234";
+	private static final String	USER_ID			= "user-1234";
+	private static final String	PASSWORD		= "1234";
+
+	// required for getting metadata in attributeStore
+	private static final String	ZONE			= "zone-1";
+	private static final String	HOST_EXT_ID		= "13422-452-1343454";
+	private static final String	HOST_EXT_NAME	= "openstack-vm-1";
+
+	// information to be returned by the mocked client
+	private static final String	FLAVOR_ID		= "14723-123-2354361";
+	private static final String	FLAVOR_NAME		= "flavor-1";
+
+	private static final int	VM_RAM			= 4096;
+	private static final int	V_CPUS			= 4;
+	private static final int	VM_DISK			= 80;
+	private static final String	SWAP_SIZE		= "2 GB";
+
+	/**
+	 * Capability to be tested
+	 */
+	IHostAdministration			openstackHostAdminCapability;
+
+	/**
+	 * Resource injected in tested capabilty
+	 */
+	IRootResource				hostResource;
+
+	/**
+	 * All capabilities dependencies (will be mocked)
+	 */
+	IServiceProvider			mockedServiceProvider;
+	IJCloudsNovaClientProvider	mockedJcloudsClientProvider;
+	NovaApi						mockedNovaApi;
+	ServerApi					mockedServerApi;
+
+	/**
+	 * Objects returned by mocked capabilities/clients.
+	 */
+	IAttributeStore				attributeStore;
+	Flavor						flavor;
+	Server						server;
+
+	@Before
+	public void prepareTest() throws ApplicationActivationException, SecurityException, IllegalArgumentException, IllegalAccessException,
+			InstantiationException, URISyntaxException, EndpointNotFoundException {
+
+		openstackHostAdminCapability = new OpenstackHostAdministration();
+
+		mockAndCreateCapabilityDependencies();
+
+		openstackHostAdminCapability.activate();
+
+	}
+
+	/**
+	 * Test checks that all services of the {@link OpenstackHostAdministration} capability return the same value as the Jclouds client retrieved from
+	 * Openstack instance.
+	 */
+	@Test
+	public void capabilityServicesTest() {
+		Assert.assertEquals("OpenstackHostAdministrationCapabiliy should return the same value the client provided.", V_CPUS,
+				openstackHostAdminCapability.getNumberOfCpus());
+
+		Assert.assertEquals("OpenstackHostAdministrationCapabiliy should return the same value the client provided.", VM_RAM,
+				openstackHostAdminCapability.getMemorySize());
+
+		Assert.assertEquals("OpenstackHostAdministrationCapabiliy should return the same value the client provided.", VM_DISK,
+				openstackHostAdminCapability.getDiskSize());
+
+		Assert.assertEquals("OpenstackHostAdministrationCapabiliy should return the same value the client provided.", SWAP_SIZE,
+				openstackHostAdminCapability.getSwapSize());
+	}
+
+	/**
+	 * Test checks that, if the {@link IAttributeStore} of the resource bound to the tested capability does not contain the resource external id, it
+	 * fails with an {@link IllegalStateException}.
+	 */
+	@Test(expected = IllegalStateException.class)
+	public void noStoredExternalId() throws SecurityException, IllegalArgumentException, IllegalAccessException {
+		ReflectionTestHelper.injectPrivateField(attributeStore, new HashMap<String, String>(), "attributes");
+		attributeStore.setAttribute(OpenstackRootResourceProvider.ZONE_ATTRIBUTE, ZONE);
+		openstackHostAdminCapability.getNumberOfCpus();
+	}
+
+	/**
+	 * Test checks that, if the {@link IAttributeStore} of the resource bound to the tested capability does not contain the Openstack zone it belongs
+	 * to, it fails with an {@link IllegalStateException}.
+	 */
+	@Test(expected = IllegalStateException.class)
+	public void noStoredZone() throws SecurityException, IllegalArgumentException, IllegalAccessException {
+		ReflectionTestHelper.injectPrivateField(attributeStore, new HashMap<String, String>(), "attributes");
+		attributeStore.setAttribute(IAttributeStore.RESOURCE_EXTERNAL_ID, HOST_EXT_ID);
+		openstackHostAdminCapability.getNumberOfCpus();
+	}
+
+	/**
+	 * Create and/or mock the dependencies of the capability to be tested, as well as the response of those componentes.
+	 */
+	private void mockAndCreateCapabilityDependencies() throws URISyntaxException, SecurityException, IllegalArgumentException,
+			IllegalAccessException, InstantiationException, EndpointNotFoundException, ApplicationActivationException {
+
+		// create and inject resource in capability
+		Specification spec = new Specification(Type.HOST, "openstack");
+		Endpoint fakeEndpoint = new Endpoint(new URI(RESOURCE_URI));
+		UsernamePasswordTenantCredentials credentials = new UsernamePasswordTenantCredentials(USER_ID, PASSWORD, TENANT_ID);
+
+		hostResource = new RootResource(RootResourceDescriptor.create(spec, Arrays.asList(fakeEndpoint), credentials));
+		ReflectionTestHelper.injectPrivateField(openstackHostAdminCapability, hostResource, "resource");
+
+		// initialize and inject attributeStore
+		attributeStore = new AttributeStore();
+		ReflectionTestHelper.injectPrivateField(attributeStore, hostResource, "resource");
+		attributeStore.activate();
+		attributeStore.setAttribute(IAttributeStore.RESOURCE_EXTERNAL_ID, HOST_EXT_ID);
+		attributeStore.setAttribute(OpenstackRootResourceProvider.ZONE_ATTRIBUTE, ZONE);
+		ReflectionTestHelper.injectPrivateField(openstackHostAdminCapability, attributeStore, "attributeStore");
+
+		// mock client
+		flavor = buildFlavorObject();
+		server = buildServerObject(HOST_EXT_ID, HOST_EXT_NAME, flavor);
+
+		mockedNovaApi = PowerMockito.mock(NovaApi.class);
+		mockedServerApi = PowerMockito.mock(ServerApi.class);
+		PowerMockito.when(mockedNovaApi.getServerApiForZone(Mockito.eq(ZONE))).thenReturn(mockedServerApi);
+		PowerMockito.when(mockedServerApi.get(Mockito.eq(HOST_EXT_ID))).thenReturn(server);
+
+		// mock jCloudsClientProvider and inject it in capability.
+		mockedJcloudsClientProvider = PowerMockito.mock(IJCloudsNovaClientProvider.class);
+		PowerMockito.when(mockedJcloudsClientProvider.getClient(Mockito.eq(hostResource))).thenReturn(mockedNovaApi);
+		ReflectionTestHelper.injectPrivateField(openstackHostAdminCapability, mockedJcloudsClientProvider, "jcloudsClientProvider");
+
+	}
+
+	/**
+	 * Builds a {@link Flavor} instance with the minimal requirements of JClouds client.
+	 */
+	private Flavor buildFlavorObject() {
+		return Flavor.builder().id(FLAVOR_ID).name(FLAVOR_NAME).vcpus(V_CPUS).ram(VM_RAM).disk(VM_DISK).swap(SWAP_SIZE).build();
+	}
+
+	/**
+	 * Builds a {@link Server} instance with the specificed server id and name, and adds all required information by JClouds to build a server
+	 * instance.
+	 */
+	private Server buildServerObject(String serverId, String serverName, Flavor flavor) {
+		return Server.builder().id(serverId).name(serverName).tenantId(TENANT_ID).userId(USER_ID)
+				.created(new Date(System.currentTimeMillis())).status(Status.ACTIVE).flavor(flavor).build();
+	}
+}


### PR DESCRIPTION
This pull request proposes the IHostAdministration capability and its implementation for the Openstack VMs.

The IHostAdministration capability is responsible of managing the hardware information of a host (or a VM in Openstack). 

Our first implementation of the OpenstackHostAdministration capability does not contain setter methods. All getter methods use the JClouds client in order to retrieve the requested information. And the capability return the same data types as the client.

Fixes: [CON-175](http://jira.i2cat.net/browse/CON-175), [CON-176](http://jira.i2cat.net/browse/CON-176)
