### PR TITLE
Feature/openstack support create ports

### DIFF
--- a/extensions/openstack/openstack-api/pom.xml
+++ b/extensions/openstack/openstack-api/pom.xml
@@ -15,6 +15,11 @@
 	<description>OpenStack Capabilities APIs and models</description>
 	
 	<dependencies>
+		<!-- MQNaaS dependencies -->
+		<dependency>
+			<groupId>org.mqnaas</groupId>
+			<artifactId>core.api</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>
@@ -27,6 +32,7 @@
 					<instructions>
 						<Import-Package>*</Import-Package>
 						<Export-Package>
+							org.mqnaas.extensions.openstack.capabilities.host.api
 						</Export-Package>
 					</instructions>
 				</configuration>

--- a/extensions/openstack/openstack-api/src/main/java/org/mqnaas/extensions/openstack/capabilities/host/api/IHostAdministration.java
+++ b/extensions/openstack/openstack-api/src/main/java/org/mqnaas/extensions/openstack/capabilities/host/api/IHostAdministration.java
@@ -43,12 +43,12 @@ public interface IHostAdministration extends ICapability {
 	/**
 	 * Returns the host amount of memory in MB.
 	 */
-	float getMemorySize();
+	int getMemorySize();
 
 	/**
 	 * Returns the Disk size in GB.
 	 */
-	float getDiskSize();
+	int getDiskSize();
 
 	/**
 	 * Returns the size of the Swap partition.

--- a/extensions/openstack/openstack-api/src/main/java/org/mqnaas/extensions/openstack/capabilities/host/api/IHostAdministration.java
+++ b/extensions/openstack/openstack-api/src/main/java/org/mqnaas/extensions/openstack/capabilities/host/api/IHostAdministration.java
@@ -1,0 +1,58 @@
+package org.mqnaas.extensions.openstack.capabilities.host.api;
+
+/*
+ * #%L
+ * MQNaaS :: OpenStack API
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i
+ * 			Innovació a Catalunya
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import org.mqnaas.core.api.ICapability;
+import org.mqnaas.core.api.IRootResource;
+import org.mqnaas.core.api.Specification.Type;
+
+/**
+ * <p>
+ * Capability providing services to set and retrieve the main hardware attributes of a {@link Type#HOST} {@link IRootResource}
+ * </p>
+ * 
+ * @author Adrian Rosello Rey (i2CAT)
+ * 
+ */
+public interface IHostAdministration extends ICapability {
+
+	/**
+	 * Returns the number of virtual CPUs of the host.
+	 */
+	int getNumberOfCpus();
+
+	/**
+	 * Returns the host amount of memory in MB.
+	 */
+	float getMemorySize();
+
+	/**
+	 * Returns the Disk size in GB.
+	 */
+	float getDiskSize();
+
+	/**
+	 * Returns the size of the Swap partition.
+	 */
+	String getSwapSize();
+
+}

--- a/extensions/openstack/openstack-impl/pom.xml
+++ b/extensions/openstack/openstack-impl/pom.xml
@@ -21,6 +21,10 @@
 			<groupId>org.mqnaas.extensions</groupId>
 			<artifactId>jclouds-client-provider</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.mqnaas.extensions</groupId>
+			<artifactId>openstack-api</artifactId>
+		</dependency>
 
 		<!-- MQNaaS modules -->
 		<dependency>

--- a/extensions/openstack/openstack-impl/pom.xml
+++ b/extensions/openstack/openstack-impl/pom.xml
@@ -32,6 +32,13 @@
 			<artifactId>core.api</artifactId>
 		</dependency>
 
+		<!-- Network module, required to manage ports -->
+		<dependency>
+			<groupId>org.mqnaas.extensions</groupId>
+			<artifactId>network.api</artifactId>
+		</dependency>
+
+
 		<!-- Testing dependencies -->
 		<dependency>
 			<groupId>org.mqnaas</groupId>

--- a/extensions/openstack/openstack-impl/pom.xml
+++ b/extensions/openstack/openstack-impl/pom.xml
@@ -60,6 +60,11 @@
 			<artifactId>powermock-module-junit4</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.mqnaas.extensions</groupId>
+			<artifactId>network.impl</artifactId>
+			<scope>test</scope>
+		</dependency>
 
 	</dependencies>
 

--- a/extensions/openstack/openstack-impl/src/main/java/org/mqnaas/extensions/openstack/capabilities/impl/OpenstackHostAdministration.java
+++ b/extensions/openstack/openstack-impl/src/main/java/org/mqnaas/extensions/openstack/capabilities/impl/OpenstackHostAdministration.java
@@ -1,5 +1,26 @@
 package org.mqnaas.extensions.openstack.capabilities.impl;
 
+/*
+ * #%L
+ * MQNaaS :: OpenStack Implementation
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i
+ * 			Innovació a Catalunya
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import java.io.IOException;
 
 import org.apache.commons.lang3.StringUtils;
@@ -95,7 +116,7 @@ public class OpenstackHostAdministration implements IHostAdministration {
 	}
 
 	@Override
-	public float getMemorySize() {
+	public int getMemorySize() {
 		log.debug("Getting memory size of host [id=" + resource.getId() + "]");
 
 		Server server = getServer();
@@ -105,7 +126,7 @@ public class OpenstackHostAdministration implements IHostAdministration {
 	}
 
 	@Override
-	public float getDiskSize() {
+	public int getDiskSize() {
 		log.debug("Getting disk size of host [id=" + resource.getId() + "]");
 
 		Server server = getServer();

--- a/extensions/openstack/openstack-impl/src/main/java/org/mqnaas/extensions/openstack/capabilities/impl/OpenstackHostAdministration.java
+++ b/extensions/openstack/openstack-impl/src/main/java/org/mqnaas/extensions/openstack/capabilities/impl/OpenstackHostAdministration.java
@@ -28,7 +28,9 @@ import org.jclouds.openstack.nova.v2_0.NovaApi;
 import org.jclouds.openstack.nova.v2_0.domain.Flavor;
 import org.jclouds.openstack.nova.v2_0.domain.Server;
 import org.jclouds.openstack.nova.v2_0.features.ServerApi;
+import org.mqnaas.clientprovider.api.client.IClientProviderFactory;
 import org.mqnaas.clientprovider.exceptions.EndpointNotFoundException;
+import org.mqnaas.clientprovider.exceptions.ProviderNotFoundException;
 import org.mqnaas.core.api.IAttributeStore;
 import org.mqnaas.core.api.IRootResource;
 import org.mqnaas.core.api.Specification;
@@ -66,7 +68,7 @@ public class OpenstackHostAdministration implements IHostAdministration {
 	IAttributeStore				attributeStore;
 
 	@DependingOn
-	IJCloudsNovaClientProvider	jcloudsClientProvider;
+	IClientProviderFactory		clientProviderFactory;
 
 	@Resource
 	IRootResource				resource;
@@ -82,8 +84,10 @@ public class OpenstackHostAdministration implements IHostAdministration {
 		log.info("Initializing OpenstackHostAdministration capability for resource " + resource.getId());
 
 		try {
-			novaClient = jcloudsClientProvider.getClient(resource);
+			novaClient = clientProviderFactory.getClientProvider(IJCloudsNovaClientProvider.class).getClient(resource);
 		} catch (EndpointNotFoundException e) {
+			throw new ApplicationActivationException("Could not instantiate JClouds client.", e);
+		} catch (ProviderNotFoundException e) {
 			throw new ApplicationActivationException("Could not instantiate JClouds client.", e);
 		}
 

--- a/extensions/openstack/openstack-impl/src/main/java/org/mqnaas/extensions/openstack/capabilities/impl/OpenstackHostAdministration.java
+++ b/extensions/openstack/openstack-impl/src/main/java/org/mqnaas/extensions/openstack/capabilities/impl/OpenstackHostAdministration.java
@@ -1,0 +1,157 @@
+package org.mqnaas.extensions.openstack.capabilities.impl;
+
+import java.io.IOException;
+
+import org.apache.commons.lang3.StringUtils;
+import org.jclouds.openstack.nova.v2_0.NovaApi;
+import org.jclouds.openstack.nova.v2_0.domain.Flavor;
+import org.jclouds.openstack.nova.v2_0.domain.Server;
+import org.jclouds.openstack.nova.v2_0.features.ServerApi;
+import org.mqnaas.clientprovider.exceptions.EndpointNotFoundException;
+import org.mqnaas.core.api.IAttributeStore;
+import org.mqnaas.core.api.IRootResource;
+import org.mqnaas.core.api.Specification;
+import org.mqnaas.core.api.Specification.Type;
+import org.mqnaas.core.api.annotations.DependingOn;
+import org.mqnaas.core.api.annotations.Resource;
+import org.mqnaas.core.api.exceptions.ApplicationActivationException;
+import org.mqnaas.extensions.openstack.capabilities.host.api.IHostAdministration;
+import org.mqnaas.extensions.openstack.jclouds.clientprovider.IJCloudsNovaClientProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.io.Closeables;
+
+/**
+ * <p>
+ * Specific implementation of the {@link IHostAdministration} capability for Openstack virtual machines.
+ * </p>
+ * 
+ * <p>
+ * This capability does not store any information about the {@link Server}. Every getter method uses the Jclouds client in order to retrieve this
+ * information from OpenStack.
+ * </p>
+ * 
+ * @author Adrian Rosello Rey (i2CAT)
+ * 
+ */
+public class OpenstackHostAdministration implements IHostAdministration {
+
+	private static final Logger	log	= LoggerFactory.getLogger(OpenstackHostAdministration.class);
+
+	private NovaApi				novaClient;
+
+	@DependingOn
+	IAttributeStore				attributeStore;
+
+	@DependingOn
+	IJCloudsNovaClientProvider	jcloudsClientProvider;
+
+	@Resource
+	IRootResource				resource;
+
+	public static boolean isSupporting(IRootResource resource) {
+		Specification resourceSpec = resource.getDescriptor().getSpecification();
+
+		return (resourceSpec.getType().equals(Type.HOST) && resourceSpec.getModel().equals("openstack"));
+	}
+
+	@Override
+	public void activate() throws ApplicationActivationException {
+		log.info("Initializing OpenstackHostAdministration capability for resource " + resource.getId());
+
+		try {
+			novaClient = jcloudsClientProvider.getClient(resource);
+		} catch (EndpointNotFoundException e) {
+			throw new ApplicationActivationException("Could not instantiate JClouds client.", e);
+		}
+
+		log.info("Initialized OpenstackHostAdministration capability for resource " + resource.getId());
+
+	}
+
+	@Override
+	public void deactivate() {
+		log.info("Removing OpenstackHostAdministration capability from resource " + resource.getId());
+
+		try {
+			Closeables.close(novaClient, true);
+		} catch (IOException e) {
+			log.warn("Could not close jclouds nova client.", e);
+		}
+
+		log.info("Removed OpenstackHostAdministration capability from resource " + resource.getId());
+
+	}
+
+	@Override
+	public int getNumberOfCpus() {
+		log.debug("Getting number of cpus of host [id=" + resource.getId() + "]");
+
+		Server server = getServer();
+		Flavor flavor = (Flavor) server.getFlavor();
+
+		return flavor.getVcpus();
+	}
+
+	@Override
+	public float getMemorySize() {
+		log.debug("Getting memory size of host [id=" + resource.getId() + "]");
+
+		Server server = getServer();
+		Flavor flavor = (Flavor) server.getFlavor();
+
+		return flavor.getRam();
+	}
+
+	@Override
+	public float getDiskSize() {
+		log.debug("Getting disk size of host [id=" + resource.getId() + "]");
+
+		Server server = getServer();
+		Flavor flavor = (Flavor) server.getFlavor();
+
+		return flavor.getDisk();
+	}
+
+	@Override
+	public String getSwapSize() {
+
+		Server server = getServer();
+		Flavor flavor = (Flavor) server.getFlavor();
+
+		return flavor.getSwap() != null ? flavor.getSwap().get() : null;
+	}
+
+	/**
+	 * Retrieves the {@link Server} instance represented by the injected <code>resource</code> by using the jclouds client.
+	 * 
+	 * @throws IllegalStateException
+	 *             <ul>
+	 *             <li>If {@link IAttributeStore} capability of the injected resource does not contain information about the {@link Server} id and the
+	 *             zone it belongs to.</li>
+	 *             <li>If there's no zone identified by the zoneId stored in IAttributeStore capability.</li>
+	 *             <li>If there's no server identified by the id stored in IAttributeStore capability.</li>
+	 *             </ul>
+	 */
+	private Server getServer() {
+
+		String zone = attributeStore.getAttribute(OpenstackRootResourceProvider.ZONE_ATTRIBUTE);
+		String vmId = attributeStore.getAttribute(IAttributeStore.RESOURCE_EXTERNAL_ID);
+
+		if (StringUtils.isEmpty(zone) || StringUtils.isEmpty(vmId))
+			throw new IllegalStateException("Can't read VM cpus if AttributeStore does not contain its external id and the zone it belongs to.");
+
+		ServerApi serverClient = novaClient.getServerApiForZone(zone);
+
+		if (serverClient == null)
+			throw new IllegalStateException("There's no configured zone with such id [zone=" + zone + "]");
+
+		Server server = serverClient.get(vmId);
+		if (server == null)
+			throw new IllegalStateException("There's no server with such id in this zone [serverId=" + vmId + ", zone=" + zone + "]");
+
+		return server;
+	}
+
+}

--- a/extensions/openstack/openstack-impl/src/main/java/org/mqnaas/extensions/openstack/capabilities/impl/OpenstackRootResourceProvider.java
+++ b/extensions/openstack/openstack-impl/src/main/java/org/mqnaas/extensions/openstack/capabilities/impl/OpenstackRootResourceProvider.java
@@ -29,12 +29,18 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.commons.lang3.StringUtils;
+import org.jclouds.openstack.neutron.v2.NeutronApi;
+import org.jclouds.openstack.neutron.v2.domain.Port;
+import org.jclouds.openstack.neutron.v2.features.PortApi;
 import org.jclouds.openstack.nova.v2_0.NovaApi;
 import org.jclouds.openstack.nova.v2_0.domain.Server;
 import org.jclouds.openstack.nova.v2_0.features.ServerApi;
+import org.mqnaas.clientprovider.api.client.IClientProviderFactory;
 import org.mqnaas.clientprovider.exceptions.EndpointNotFoundException;
+import org.mqnaas.clientprovider.exceptions.ProviderNotFoundException;
 import org.mqnaas.core.api.Endpoint;
 import org.mqnaas.core.api.IAttributeStore;
+import org.mqnaas.core.api.IResource;
 import org.mqnaas.core.api.IResourceManagementListener;
 import org.mqnaas.core.api.IRootResource;
 import org.mqnaas.core.api.IRootResourceProvider;
@@ -50,7 +56,9 @@ import org.mqnaas.core.api.exceptions.ApplicationNotFoundException;
 import org.mqnaas.core.api.exceptions.CapabilityNotFoundException;
 import org.mqnaas.core.api.exceptions.ResourceNotFoundException;
 import org.mqnaas.core.impl.RootResource;
+import org.mqnaas.extensions.openstack.jclouds.clientprovider.IJCloudsNeutronClientProvider;
 import org.mqnaas.extensions.openstack.jclouds.clientprovider.IJCloudsNovaClientProvider;
+import org.mqnaas.network.api.topology.port.IPortManagement;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -81,17 +89,19 @@ public class OpenstackRootResourceProvider implements IRootResourceProvider {
 
 	private NovaApi						novaClient;
 
-	@DependingOn
-	IResourceManagementListener			resourceManagementListener;
+	private NeutronApi					neutronClient;
 
 	@DependingOn
-	IJCloudsNovaClientProvider			jcloudsClientProvider;
+	IResourceManagementListener			resourceManagementListener;
 
 	@DependingOn
 	IResourceManagementListener			rmListener;
 
 	@DependingOn
 	IServiceProvider					serviceProvider;
+
+	@DependingOn
+	IClientProviderFactory				clientProviderFactory;
 
 	@Resource
 	IRootResource						resource;
@@ -108,15 +118,18 @@ public class OpenstackRootResourceProvider implements IRootResourceProvider {
 		log.info("Initializing OpenstackRootResourceProvider capability for resource " + resource.getId());
 
 		try {
-			novaClient = jcloudsClientProvider.getClient(resource);
+			novaClient = clientProviderFactory.getClientProvider(IJCloudsNovaClientProvider.class).getClient(resource);
+			neutronClient = clientProviderFactory.getClientProvider(IJCloudsNeutronClientProvider.class).getClient(resource);
 		} catch (EndpointNotFoundException e) {
+			throw new ApplicationActivationException("Could not instantiate JClouds client.", e);
+		} catch (ProviderNotFoundException e) {
 			throw new ApplicationActivationException("Could not instantiate JClouds client.", e);
 		}
 
 		try {
 			initializeVms();
 		} catch (Exception e) {
-			throw new ApplicationActivationException("Cloud not initialize Openstack VMs.", e);
+			throw new ApplicationActivationException("Could not initialize Openstack VMs.", e);
 		}
 		log.info("Initialized OpenstackRootResourceProvider capability for resource " + resource.getId());
 
@@ -199,11 +212,8 @@ public class OpenstackRootResourceProvider implements IRootResourceProvider {
 
 				log.debug("Instantied Openstack VM [MqNaas-id=" + rootResource.getId() + ", Openstack-id=" + server.getId() + "]");
 
-				IAttributeStore attrStore = serviceProvider.getCapability(rootResource, IAttributeStore.class);
-
-				attrStore.setAttribute(ZONE_ATTRIBUTE, zone);
-				attrStore.setAttribute(IAttributeStore.RESOURCE_EXTERNAL_ID, server.getId());
-				attrStore.setAttribute(IAttributeStore.RESOURCE_EXTERNAL_NAME, server.getName());
+				storeMetadataInAttributeStore(rootResource, server, zone);
+				createResourcePorts(rootResource, server, zone);
 
 				vms.put(rootResource.getId(), rootResource);
 			}
@@ -226,5 +236,65 @@ public class OpenstackRootResourceProvider implements IRootResourceProvider {
 		vm.getDescriptor().setCredentials(resource.getDescriptor().getCredentials());
 
 		return vm;
+	}
+
+	/**
+	 * Stores the resource external id and name in the <code>rootResource</code> {@link IAttributeStore} capability, as well as the Openstack zone the
+	 * given {@link Server} belongs to.
+	 *
+	 * @param rootResource
+	 *            MQNaaS representation of the Openstack {@link Server}
+	 * @param server
+	 *            The Openstack VM.
+	 * @param zone
+	 *            Openstack zone the VM belongs to.
+	 * @throws CapabilityNotFoundException
+	 *             If the given {@link IRootResource} does not have a bound {@link IAttributeStore} capability.
+	 */
+	private void storeMetadataInAttributeStore(IRootResource rootResource, Server server, String zone) throws CapabilityNotFoundException {
+
+		IAttributeStore attrStore = serviceProvider.getCapability(rootResource, IAttributeStore.class);
+
+		attrStore.setAttribute(ZONE_ATTRIBUTE, zone);
+		attrStore.setAttribute(IAttributeStore.RESOURCE_EXTERNAL_ID, server.getId());
+		attrStore.setAttribute(IAttributeStore.RESOURCE_EXTERNAL_NAME, server.getName());
+
+	}
+
+	/**
+	 * For each {@link Port} contained in the given {@link Server}, it creates an MQNaaS {@link IResource port resource} in the {@link IRootResource}
+	 * representing the Openstack server. Each MQNaaS port will contain the external id and name in its {@link IAttributeStore} capability.
+	 * 
+	 * @param rootResource
+	 *            Representation of the Openstack server in MQNaaS.
+	 * @param server
+	 *            Openstack VM represented by the <code>rootResource</code> parameter.
+	 * @param zone
+	 *            Openstack zone the server belongs to.
+	 * @throws CapabilityNotFoundException
+	 *             If the given rootResource does not contain a {@link IPortManagement} capability, and also the created ports does not contain
+	 *             {@link IAttributeStore} capability bound to store port metadata.
+	 */
+	private void createResourcePorts(IRootResource rootResource, Server server, String zone) throws CapabilityNotFoundException {
+
+		log.info("Creating ports for rootResource [id=" + rootResource.getId() + "]");
+
+		IPortManagement portMgmnt = serviceProvider.getCapability(rootResource, IPortManagement.class);
+
+		PortApi portApi = neutronClient.getPortApi(zone);
+
+		for (Port openstackPort : portApi.list().concat()) {
+			if (StringUtils.equals(server.getId(), openstackPort.getDeviceId())) {
+
+				log.debug("Port found [resourceId=" + rootResource.getId() + ", portName=[ " + openstackPort.getName() + ", portId=" + openstackPort
+						.getId() + "]");
+
+				IResource mqnaasPort = portMgmnt.createPort();
+				IAttributeStore portAttrStore = serviceProvider.getCapability(mqnaasPort, IAttributeStore.class);
+				portAttrStore.setAttribute(IAttributeStore.RESOURCE_EXTERNAL_ID, openstackPort.getId());
+				portAttrStore.setAttribute(IAttributeStore.RESOURCE_EXTERNAL_NAME, openstackPort.getName());
+			}
+		}
+
 	}
 }

--- a/extensions/openstack/openstack-impl/src/test/java/org/mqnaas/extensions/openstack/capabilities/impl/OpenstackHostAdministrationTest.java
+++ b/extensions/openstack/openstack-impl/src/test/java/org/mqnaas/extensions/openstack/capabilities/impl/OpenstackHostAdministrationTest.java
@@ -36,7 +36,9 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
+import org.mqnaas.clientprovider.api.client.IClientProviderFactory;
 import org.mqnaas.clientprovider.exceptions.EndpointNotFoundException;
+import org.mqnaas.clientprovider.exceptions.ProviderNotFoundException;
 import org.mqnaas.core.api.Endpoint;
 import org.mqnaas.core.api.IAttributeStore;
 import org.mqnaas.core.api.IRootResource;
@@ -112,7 +114,7 @@ public class OpenstackHostAdministrationTest {
 
 	@Before
 	public void prepareTest() throws ApplicationActivationException, SecurityException, IllegalArgumentException, IllegalAccessException,
-			InstantiationException, URISyntaxException, EndpointNotFoundException {
+			InstantiationException, URISyntaxException, EndpointNotFoundException, ProviderNotFoundException {
 
 		openstackHostAdminCapability = new OpenstackHostAdministration();
 
@@ -165,9 +167,11 @@ public class OpenstackHostAdministrationTest {
 
 	/**
 	 * Create and/or mock the dependencies of the capability to be tested, as well as the response of those componentes.
+	 * 
+	 * @throws ProviderNotFoundException
 	 */
 	private void mockAndCreateCapabilityDependencies() throws URISyntaxException, SecurityException, IllegalArgumentException,
-			IllegalAccessException, InstantiationException, EndpointNotFoundException, ApplicationActivationException {
+			IllegalAccessException, InstantiationException, EndpointNotFoundException, ApplicationActivationException, ProviderNotFoundException {
 
 		// create and inject resource in capability
 		Specification spec = new Specification(Type.HOST, "openstack");
@@ -195,9 +199,13 @@ public class OpenstackHostAdministrationTest {
 		PowerMockito.when(mockedServerApi.get(Mockito.eq(HOST_EXT_ID))).thenReturn(server);
 
 		// mock jCloudsClientProvider and inject it in capability.
+
 		mockedJcloudsClientProvider = PowerMockito.mock(IJCloudsNovaClientProvider.class);
 		PowerMockito.when(mockedJcloudsClientProvider.getClient(Mockito.eq(hostResource))).thenReturn(mockedNovaApi);
-		ReflectionTestHelper.injectPrivateField(openstackHostAdminCapability, mockedJcloudsClientProvider, "jcloudsClientProvider");
+		IClientProviderFactory mockedClientProviderFactory = PowerMockito.mock(IClientProviderFactory.class);
+		PowerMockito.when(mockedClientProviderFactory.getClientProvider(Mockito.eq(IJCloudsNovaClientProvider.class))).thenReturn(
+				mockedJcloudsClientProvider);
+		ReflectionTestHelper.injectPrivateField(openstackHostAdminCapability, mockedClientProviderFactory, "clientProviderFactory");
 
 	}
 

--- a/extensions/openstack/openstack-impl/src/test/java/org/mqnaas/extensions/openstack/capabilities/impl/OpenstackHostAdministrationTest.java
+++ b/extensions/openstack/openstack-impl/src/test/java/org/mqnaas/extensions/openstack/capabilities/impl/OpenstackHostAdministrationTest.java
@@ -1,0 +1,219 @@
+package org.mqnaas.extensions.openstack.capabilities.impl;
+
+/*
+ * #%L
+ * MQNaaS :: OpenStack Implementation
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i
+ * 			Innovació a Catalunya
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashMap;
+
+import org.jclouds.openstack.nova.v2_0.NovaApi;
+import org.jclouds.openstack.nova.v2_0.domain.Flavor;
+import org.jclouds.openstack.nova.v2_0.domain.Server;
+import org.jclouds.openstack.nova.v2_0.domain.Server.Status;
+import org.jclouds.openstack.nova.v2_0.features.ServerApi;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.mqnaas.clientprovider.exceptions.EndpointNotFoundException;
+import org.mqnaas.core.api.Endpoint;
+import org.mqnaas.core.api.IAttributeStore;
+import org.mqnaas.core.api.IRootResource;
+import org.mqnaas.core.api.IServiceProvider;
+import org.mqnaas.core.api.RootResourceDescriptor;
+import org.mqnaas.core.api.Specification;
+import org.mqnaas.core.api.Specification.Type;
+import org.mqnaas.core.api.credentials.UsernamePasswordTenantCredentials;
+import org.mqnaas.core.api.exceptions.ApplicationActivationException;
+import org.mqnaas.core.impl.AttributeStore;
+import org.mqnaas.core.impl.RootResource;
+import org.mqnaas.extensions.openstack.capabilities.host.api.IHostAdministration;
+import org.mqnaas.extensions.openstack.jclouds.clientprovider.IJCloudsNovaClientProvider;
+import org.mqnaas.general.test.helpers.reflection.ReflectionTestHelper;
+import org.powermock.api.mockito.PowerMockito;
+
+/**
+ * <p>
+ * Unitary tests for the {@link OpenstackHostAdministration} capability.
+ * </p>
+ * 
+ * @author Adrian Rosello Rey (i2CAT)
+ *
+ */
+public class OpenstackHostAdministrationTest {
+
+	// used to create the endpoint of the resource the capability is bound to.
+	private static final String	RESOURCE_URI	= "http://www.myfakeresource.com/";
+
+	// required to jclouds clientprovider to instantiate client.
+	private static final String	TENANT_ID		= "tenant-1234";
+	private static final String	USER_ID			= "user-1234";
+	private static final String	PASSWORD		= "1234";
+
+	// required for getting metadata in attributeStore
+	private static final String	ZONE			= "zone-1";
+	private static final String	HOST_EXT_ID		= "13422-452-1343454";
+	private static final String	HOST_EXT_NAME	= "openstack-vm-1";
+
+	// information to be returned by the mocked client
+	private static final String	FLAVOR_ID		= "14723-123-2354361";
+	private static final String	FLAVOR_NAME		= "flavor-1";
+
+	private static final int	VM_RAM			= 4096;
+	private static final int	V_CPUS			= 4;
+	private static final int	VM_DISK			= 80;
+	private static final String	SWAP_SIZE		= "2 GB";
+
+	/**
+	 * Capability to be tested
+	 */
+	IHostAdministration			openstackHostAdminCapability;
+
+	/**
+	 * Resource injected in tested capabilty
+	 */
+	IRootResource				hostResource;
+
+	/**
+	 * All capabilities dependencies (will be mocked)
+	 */
+	IServiceProvider			mockedServiceProvider;
+	IJCloudsNovaClientProvider	mockedJcloudsClientProvider;
+	NovaApi						mockedNovaApi;
+	ServerApi					mockedServerApi;
+
+	/**
+	 * Objects returned by mocked capabilities/clients.
+	 */
+	IAttributeStore				attributeStore;
+	Flavor						flavor;
+	Server						server;
+
+	@Before
+	public void prepareTest() throws ApplicationActivationException, SecurityException, IllegalArgumentException, IllegalAccessException,
+			InstantiationException, URISyntaxException, EndpointNotFoundException {
+
+		openstackHostAdminCapability = new OpenstackHostAdministration();
+
+		mockAndCreateCapabilityDependencies();
+
+		openstackHostAdminCapability.activate();
+
+	}
+
+	/**
+	 * Test checks that all services of the {@link OpenstackHostAdministration} capability return the same value as the Jclouds client retrieved from
+	 * Openstack instance.
+	 */
+	@Test
+	public void capabilityServicesTest() {
+		Assert.assertEquals("OpenstackHostAdministrationCapabiliy should return the same value the client provided.", V_CPUS,
+				openstackHostAdminCapability.getNumberOfCpus());
+
+		Assert.assertEquals("OpenstackHostAdministrationCapabiliy should return the same value the client provided.", VM_RAM,
+				openstackHostAdminCapability.getMemorySize());
+
+		Assert.assertEquals("OpenstackHostAdministrationCapabiliy should return the same value the client provided.", VM_DISK,
+				openstackHostAdminCapability.getDiskSize());
+
+		Assert.assertEquals("OpenstackHostAdministrationCapabiliy should return the same value the client provided.", SWAP_SIZE,
+				openstackHostAdminCapability.getSwapSize());
+	}
+
+	/**
+	 * Test checks that, if the {@link IAttributeStore} of the resource bound to the tested capability does not contain the resource external id, it
+	 * fails with an {@link IllegalStateException}.
+	 */
+	@Test(expected = IllegalStateException.class)
+	public void noStoredExternalId() throws SecurityException, IllegalArgumentException, IllegalAccessException {
+		ReflectionTestHelper.injectPrivateField(attributeStore, new HashMap<String, String>(), "attributes");
+		attributeStore.setAttribute(OpenstackRootResourceProvider.ZONE_ATTRIBUTE, ZONE);
+		openstackHostAdminCapability.getNumberOfCpus();
+	}
+
+	/**
+	 * Test checks that, if the {@link IAttributeStore} of the resource bound to the tested capability does not contain the Openstack zone it belongs
+	 * to, it fails with an {@link IllegalStateException}.
+	 */
+	@Test(expected = IllegalStateException.class)
+	public void noStoredZone() throws SecurityException, IllegalArgumentException, IllegalAccessException {
+		ReflectionTestHelper.injectPrivateField(attributeStore, new HashMap<String, String>(), "attributes");
+		attributeStore.setAttribute(IAttributeStore.RESOURCE_EXTERNAL_ID, HOST_EXT_ID);
+		openstackHostAdminCapability.getNumberOfCpus();
+	}
+
+	/**
+	 * Create and/or mock the dependencies of the capability to be tested, as well as the response of those componentes.
+	 */
+	private void mockAndCreateCapabilityDependencies() throws URISyntaxException, SecurityException, IllegalArgumentException,
+			IllegalAccessException, InstantiationException, EndpointNotFoundException, ApplicationActivationException {
+
+		// create and inject resource in capability
+		Specification spec = new Specification(Type.HOST, "openstack");
+		Endpoint fakeEndpoint = new Endpoint(new URI(RESOURCE_URI));
+		UsernamePasswordTenantCredentials credentials = new UsernamePasswordTenantCredentials(USER_ID, PASSWORD, TENANT_ID);
+
+		hostResource = new RootResource(RootResourceDescriptor.create(spec, Arrays.asList(fakeEndpoint), credentials));
+		ReflectionTestHelper.injectPrivateField(openstackHostAdminCapability, hostResource, "resource");
+
+		// initialize and inject attributeStore
+		attributeStore = new AttributeStore();
+		ReflectionTestHelper.injectPrivateField(attributeStore, hostResource, "resource");
+		attributeStore.activate();
+		attributeStore.setAttribute(IAttributeStore.RESOURCE_EXTERNAL_ID, HOST_EXT_ID);
+		attributeStore.setAttribute(OpenstackRootResourceProvider.ZONE_ATTRIBUTE, ZONE);
+		ReflectionTestHelper.injectPrivateField(openstackHostAdminCapability, attributeStore, "attributeStore");
+
+		// mock client
+		flavor = buildFlavorObject();
+		server = buildServerObject(HOST_EXT_ID, HOST_EXT_NAME, flavor);
+
+		mockedNovaApi = PowerMockito.mock(NovaApi.class);
+		mockedServerApi = PowerMockito.mock(ServerApi.class);
+		PowerMockito.when(mockedNovaApi.getServerApiForZone(Mockito.eq(ZONE))).thenReturn(mockedServerApi);
+		PowerMockito.when(mockedServerApi.get(Mockito.eq(HOST_EXT_ID))).thenReturn(server);
+
+		// mock jCloudsClientProvider and inject it in capability.
+		mockedJcloudsClientProvider = PowerMockito.mock(IJCloudsNovaClientProvider.class);
+		PowerMockito.when(mockedJcloudsClientProvider.getClient(Mockito.eq(hostResource))).thenReturn(mockedNovaApi);
+		ReflectionTestHelper.injectPrivateField(openstackHostAdminCapability, mockedJcloudsClientProvider, "jcloudsClientProvider");
+
+	}
+
+	/**
+	 * Builds a {@link Flavor} instance with the minimal requirements of JClouds client.
+	 */
+	private Flavor buildFlavorObject() {
+		return Flavor.builder().id(FLAVOR_ID).name(FLAVOR_NAME).vcpus(V_CPUS).ram(VM_RAM).disk(VM_DISK).swap(SWAP_SIZE).build();
+	}
+
+	/**
+	 * Builds a {@link Server} instance with the specificed server id and name, and adds all required information by JClouds to build a server
+	 * instance.
+	 */
+	private Server buildServerObject(String serverId, String serverName, Flavor flavor) {
+		return Server.builder().id(serverId).name(serverName).tenantId(TENANT_ID).userId(USER_ID)
+				.created(new Date(System.currentTimeMillis())).status(Status.ACTIVE).flavor(flavor).build();
+	}
+}

--- a/extensions/openstack/openstack-impl/src/test/java/org/mqnaas/extensions/openstack/capabilities/impl/OpenstackRootResourceProviderTest.java
+++ b/extensions/openstack/openstack-impl/src/test/java/org/mqnaas/extensions/openstack/capabilities/impl/OpenstackRootResourceProviderTest.java
@@ -32,6 +32,9 @@ import java.util.Set;
 
 import org.apache.cxf.common.util.SortedArraySet;
 import org.jclouds.collect.PagedIterable;
+import org.jclouds.openstack.neutron.v2.NeutronApi;
+import org.jclouds.openstack.neutron.v2.domain.Port;
+import org.jclouds.openstack.neutron.v2.features.PortApi;
 import org.jclouds.openstack.nova.v2_0.NovaApi;
 import org.jclouds.openstack.nova.v2_0.domain.Server;
 import org.jclouds.openstack.nova.v2_0.domain.Server.Status;
@@ -41,7 +44,9 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
+import org.mqnaas.clientprovider.api.client.IClientProviderFactory;
 import org.mqnaas.clientprovider.exceptions.EndpointNotFoundException;
+import org.mqnaas.clientprovider.exceptions.ProviderNotFoundException;
 import org.mqnaas.core.api.Endpoint;
 import org.mqnaas.core.api.IAttributeStore;
 import org.mqnaas.core.api.IResourceManagementListener;
@@ -57,8 +62,11 @@ import org.mqnaas.core.api.exceptions.ApplicationActivationException;
 import org.mqnaas.core.api.exceptions.CapabilityNotFoundException;
 import org.mqnaas.core.impl.AttributeStore;
 import org.mqnaas.core.impl.RootResource;
+import org.mqnaas.extensions.openstack.jclouds.clientprovider.IJCloudsNeutronClientProvider;
 import org.mqnaas.extensions.openstack.jclouds.clientprovider.IJCloudsNovaClientProvider;
 import org.mqnaas.general.test.helpers.reflection.ReflectionTestHelper;
+import org.mqnaas.network.api.topology.port.IPortManagement;
+import org.mqnaas.network.impl.topology.port.PortResource;
 import org.powermock.api.mockito.PowerMockito;
 
 import com.google.common.collect.FluentIterable;
@@ -74,52 +82,76 @@ import com.google.common.collect.FluentIterable;
 public class OpenstackRootResourceProviderTest {
 
 	// used to create the endpoint of the resource the capability is bound to.
-	private static final String	RESOURCE_URI		= "http://www.myfakeresource.com/";
+	private static final String		RESOURCE_URI				= "http://www.myfakeresource.com/";
 	// user to create credentials of the ersource the capability is bound to.
-	private final static String	PASSWORD			= "1234";
+	private final static String		PASSWORD					= "1234";
 
 	// constants user to create the mocked client response
-	private final static String	ZONE_A				= "RegionOne";
-	private final static String	ZONE_B				= "RegionTwo";
+	private final static String		ZONE_A						= "RegionOne";
+	private final static String		ZONE_B						= "RegionTwo";
 
-	private final static String	SERVER_ONE_ID		= "23424-234346-13";
-	private final static String	SERVER_TWO_ID		= "76878-123323-54";
-	private final static String	SERVER_THREE_ID		= "54353-742572-37";
+	private final static String		SERVER_ONE_ID				= "23424-234346-13";
+	private final static String		SERVER_TWO_ID				= "76878-123323-54";
+	private final static String		SERVER_THREE_ID				= "54353-742572-37";
 
-	private final static String	SERVER_ONE_NAME		= "server1";
-	private final static String	SERVER_TWO_NAME		= "server2";
-	private final static String	SERVER_THREE_NAME	= "server3";
+	private final static String		SERVER_ONE_NAME				= "server1";
+	private final static String		SERVER_TWO_NAME				= "server2";
+	private final static String		SERVER_THREE_NAME			= "server3";
+
+	private final static String		SERVER_ONE_PORT_ONE_ID		= "1343-123-334";
+	private final static String		SERVER_ONE_PORT_TWO_ID		= "9393-246-161";
+	private final static String		SERVER_THREE_PORT_ONE_ID	= "4375-926-711";
+
+	private final static String		SERVER_ONE_PORT_ONE_NAME	= "port-1-1";
+	private final static String		SERVER_ONE_PORT_TWO_NAME	= "port-1-2";
+	private final static String		SERVER_THREE_PORT_ONE_NAME	= "port-3-1";
 
 	// required by JClouds to build "server" object
-	private static final String	TENANT_ID			= "tenant-1234";
-	private static final String	USER_ID				= "user-1234";
+	private static final String		TENANT_ID					= "tenant-1234";
+	private static final String		USER_ID						= "user-1234";
 
 	/**
-	 * AttributeStores capabilities for the VMs returned by mocked service provider
+	 * AttributeStores capabilities for the VMs and ports returned by mocked service provider
 	 */
-	IAttributeStore				attributeStoreServerOne;
-	IAttributeStore				attributeStoreServerTwo;
-	IAttributeStore				attributeStoreServerThree;
+	IAttributeStore					attributeStoreServerOne;
+	IAttributeStore					attributeStoreServerTwo;
+	IAttributeStore					attributeStoreServerThree;
+	IAttributeStore					attributeStoreServerOnePortOne;
+	IAttributeStore					attributeStoreServerOnePortTwo;
+	IAttributeStore					attributeStoreServerThreePortOne;
+
 	/**
 	 * Resource injected in capability.
 	 */
-	IRootResource				openstackResource;
+	IRootResource					openstackResource;
 
 	/**
 	 * Capability to be tested
 	 */
-	IRootResourceProvider		openstackRootResourceProvider;
+	IRootResourceProvider			openstackRootResourceProvider;
 
 	/**
 	 * All capabilities dependencies (will be mocked)
 	 */
-	IServiceProvider			mockedServiceProvider;
-	IJCloudsNovaClientProvider	mockedJcloudsClientProvider;
-	NovaApi						mockedNovaApi;
+	IServiceProvider				mockedServiceProvider;
+	IJCloudsNovaClientProvider		mockedJcloudsNovaClientProvider;
+	IJCloudsNeutronClientProvider	mockedJcloudsNeutronClientProvider;
+
+	NeutronApi						mockedNeutronApi;
+	NovaApi							mockedNovaApi;
+	IClientProviderFactory			mockedClientProviderFactory;
+	PortApi							mockedPortApiZoneA;
+	PortApi							mockedPortApiZoneB;
+
+	IPortManagement					mockedPortManagementCapab;
+
+	PortResource					portResourceServerOnePortOne;
+	PortResource					portResourceServerOnePortTwo;
+	PortResource					portResourceServerThreePortOne;
 
 	@Before
 	public void prepareTest() throws EndpointNotFoundException, SecurityException, IllegalArgumentException, IllegalAccessException,
-			CapabilityNotFoundException, InstantiationException, URISyntaxException {
+			CapabilityNotFoundException, InstantiationException, URISyntaxException, ProviderNotFoundException {
 		openstackRootResourceProvider = new OpenstackRootResourceProvider();
 		mockCapabilityDependencies();
 	}
@@ -151,6 +183,10 @@ public class OpenstackRootResourceProviderTest {
 		checkResouceAttributeStore(attributeStoreServerTwo, SERVER_TWO_ID, SERVER_TWO_NAME, ZONE_A);
 		checkResouceAttributeStore(attributeStoreServerThree, SERVER_THREE_ID, SERVER_THREE_NAME, ZONE_B);
 
+		checkPortAttributeStore(attributeStoreServerOnePortOne, SERVER_ONE_PORT_ONE_ID, SERVER_ONE_PORT_ONE_NAME);
+		checkPortAttributeStore(attributeStoreServerOnePortTwo, SERVER_ONE_PORT_TWO_ID, SERVER_ONE_PORT_TWO_NAME);
+		checkPortAttributeStore(attributeStoreServerThreePortOne, SERVER_THREE_PORT_ONE_ID, SERVER_THREE_PORT_ONE_NAME);
+
 	}
 
 	/**
@@ -174,6 +210,19 @@ public class OpenstackRootResourceProviderTest {
 
 		Assert.assertEquals("VM representation should belong to zone " + zone,
 				resourceAttributeStore.getAttribute(OpenstackRootResourceProvider.ZONE_ATTRIBUTE), zone);
+	}
+
+	private void checkPortAttributeStore(IAttributeStore portAttributeStore, String portExternalId, String portExternalName) {
+
+		Assert.assertNotNull("AttributeStore should contain the external id of port.",
+				portAttributeStore.getAttribute(IAttributeStore.RESOURCE_EXTERNAL_ID));
+		Assert.assertEquals("Port representation should contain the externalId " + portExternalId, portExternalId,
+				portAttributeStore.getAttribute(IAttributeStore.RESOURCE_EXTERNAL_ID));
+
+		Assert.assertNotNull("AttributeStore should contain the external name of port.",
+				portAttributeStore.getAttribute(IAttributeStore.RESOURCE_EXTERNAL_NAME));
+		Assert.assertEquals("Port representation should contain the externalName " + portExternalName,
+				portAttributeStore.getAttribute(IAttributeStore.RESOURCE_EXTERNAL_NAME), portExternalName);
 	}
 
 	/**
@@ -201,9 +250,11 @@ public class OpenstackRootResourceProviderTest {
 
 	/**
 	 * Mock and inject required capabilities and resources in the tested capability.
+	 * 
+	 * @throws ProviderNotFoundException
 	 */
 	private void mockCapabilityDependencies() throws EndpointNotFoundException, SecurityException, IllegalArgumentException, IllegalAccessException,
-			CapabilityNotFoundException, InstantiationException, URISyntaxException {
+			CapabilityNotFoundException, InstantiationException, URISyntaxException, ProviderNotFoundException {
 
 		// create and inject resource in capability
 
@@ -237,14 +288,43 @@ public class OpenstackRootResourceProviderTest {
 		PowerMockito.when(serverApiRegionOne.listInDetail()).thenReturn(serverApiRegionOneServers);
 		PowerMockito.when(serverApiRegionTwo.listInDetail()).thenReturn(serverApiRegionTwoServers);
 
-		PowerMockito.when(serverApiRegionOneServers.concat()).thenReturn(new dummyServerFluentIterable(serverOne, serverTwo));
-		PowerMockito.when(serverApiRegionTwoServers.concat()).thenReturn(new dummyServerFluentIterable(serverThree));
+		PowerMockito.when(serverApiRegionOneServers.concat()).thenReturn(new dummyFluentIterable<Server>(serverOne, serverTwo));
+		PowerMockito.when(serverApiRegionTwoServers.concat()).thenReturn(new dummyFluentIterable<Server>(serverThree));
 
 		// mock resourceManagementListener
 		IResourceManagementListener rmListener = PowerMockito.mock(IResourceManagementListener.class);
 		ReflectionTestHelper.injectPrivateField(openstackRootResourceProvider, rmListener, "resourceManagementListener");
 
-		// mock attributeStores
+		// mock PortAPI
+		mockedPortApiZoneA = PowerMockito.mock(PortApi.class);
+		mockedPortApiZoneB = PowerMockito.mock(PortApi.class);
+
+		// mock PortAPI.getPorts
+		Port port1 = buildPortObject(SERVER_ONE_PORT_ONE_ID, SERVER_ONE_PORT_ONE_NAME, SERVER_ONE_ID);
+		Port port2 = buildPortObject(SERVER_ONE_PORT_TWO_ID, SERVER_ONE_PORT_TWO_NAME, SERVER_ONE_ID);
+		Port port3 = buildPortObject(SERVER_THREE_PORT_ONE_ID, SERVER_THREE_PORT_ONE_NAME, SERVER_THREE_ID);
+
+		PagedIterable<Port> mockedIterableZoneA = PowerMockito.mock(PagedIterable.class);
+		PagedIterable<Port> mockedIterableZoneB = PowerMockito.mock(PagedIterable.class);
+		PowerMockito.when(mockedPortApiZoneA.list()).thenReturn(mockedIterableZoneA);
+		PowerMockito.when(mockedPortApiZoneB.list()).thenReturn(mockedIterableZoneB);
+		PowerMockito.when(mockedIterableZoneA.concat()).thenReturn(new dummyFluentIterable<Port>(port1, port2));
+		PowerMockito.when(mockedIterableZoneB.concat()).thenReturn(new dummyFluentIterable<Port>(port3));
+
+		// mock NeutronAPI
+		mockedNeutronApi = PowerMockito.mock(NeutronApi.class);
+		PowerMockito.when(mockedNeutronApi.getPortApi(Mockito.eq(ZONE_A))).thenReturn(mockedPortApiZoneA);
+		PowerMockito.when(mockedNeutronApi.getPortApi(Mockito.eq(ZONE_B))).thenReturn(mockedPortApiZoneB);
+
+		// mock ports attributeStores
+		attributeStoreServerOnePortOne = new AttributeStore();
+		attributeStoreServerOnePortTwo = new AttributeStore();
+		attributeStoreServerThreePortOne = new AttributeStore();
+		ReflectionTestHelper.injectPrivateField(attributeStoreServerOnePortOne, new HashMap<String, String>(), "attributes");
+		ReflectionTestHelper.injectPrivateField(attributeStoreServerOnePortTwo, new HashMap<String, String>(), "attributes");
+		ReflectionTestHelper.injectPrivateField(attributeStoreServerThreePortOne, new HashMap<String, String>(), "attributes");
+
+		// mock server attributeStores
 		attributeStoreServerOne = new AttributeStore();
 		attributeStoreServerTwo = new AttributeStore();
 		attributeStoreServerThree = new AttributeStore();
@@ -253,16 +333,40 @@ public class OpenstackRootResourceProviderTest {
 		ReflectionTestHelper.injectPrivateField(attributeStoreServerThree, new HashMap<String, String>(), "attributes");
 
 		// mock jCloudsClientProvider and inject it in capability.
-		mockedJcloudsClientProvider = PowerMockito.mock(IJCloudsNovaClientProvider.class);
-		PowerMockito.when(mockedJcloudsClientProvider.getClient(Mockito.eq(openstackResource))).thenReturn(mockedNovaApi);
+		mockedJcloudsNovaClientProvider = PowerMockito.mock(IJCloudsNovaClientProvider.class);
+		mockedJcloudsNeutronClientProvider = PowerMockito.mock(IJCloudsNeutronClientProvider.class);
 
-		ReflectionTestHelper.injectPrivateField(openstackRootResourceProvider, mockedJcloudsClientProvider, "jcloudsClientProvider");
+		mockedClientProviderFactory = PowerMockito.mock(IClientProviderFactory.class);
+		PowerMockito.when(mockedClientProviderFactory.getClientProvider(Mockito.eq(IJCloudsNovaClientProvider.class))).thenReturn(
+				mockedJcloudsNovaClientProvider);
+		PowerMockito.when(mockedJcloudsNovaClientProvider.getClient(Mockito.eq(openstackResource))).thenReturn(mockedNovaApi);
+		PowerMockito.when(mockedClientProviderFactory.getClientProvider(Mockito.eq(IJCloudsNeutronClientProvider.class))).thenReturn(
+				mockedJcloudsNeutronClientProvider);
+		PowerMockito.when(mockedJcloudsNeutronClientProvider.getClient(Mockito.eq(openstackResource))).thenReturn(mockedNeutronApi);
+		ReflectionTestHelper.injectPrivateField(openstackRootResourceProvider, mockedClientProviderFactory, "clientProviderFactory");
+
+		// mock portManagement capabilities
+		portResourceServerOnePortOne = PowerMockito.mock(PortResource.class);
+		portResourceServerOnePortTwo = PowerMockito.mock(PortResource.class);
+		portResourceServerThreePortOne = PowerMockito.mock(PortResource.class);
+
+		mockedPortManagementCapab = PowerMockito.mock(IPortManagement.class);
+		PowerMockito.when(mockedPortManagementCapab.createPort()).thenReturn(portResourceServerOnePortOne)
+				.thenReturn(portResourceServerOnePortTwo).thenReturn(portResourceServerThreePortOne);
 
 		// mock and inject service provider
-
 		IServiceProvider serviceProvider = PowerMockito.mock(IServiceProvider.class);
+
 		PowerMockito.when(serviceProvider.getCapability(Mockito.any(IRootResource.class), Mockito.eq(IAttributeStore.class)))
 				.thenReturn(attributeStoreServerOne).thenReturn(attributeStoreServerTwo).thenReturn(attributeStoreServerThree);
+		PowerMockito.when(serviceProvider.getCapability(Mockito.eq(portResourceServerOnePortOne), Mockito.eq(IAttributeStore.class))).thenReturn(
+				attributeStoreServerOnePortOne);
+		PowerMockito.when(serviceProvider.getCapability(Mockito.eq(portResourceServerOnePortTwo), Mockito.eq(IAttributeStore.class))).thenReturn(
+				attributeStoreServerOnePortTwo);
+		PowerMockito.when(serviceProvider.getCapability(Mockito.eq(portResourceServerThreePortOne), Mockito.eq(IAttributeStore.class))).thenReturn(
+				attributeStoreServerThreePortOne);
+		PowerMockito.when(serviceProvider.getCapability(Mockito.any(IRootResource.class), Mockito.eq(IPortManagement.class))).thenReturn(
+				mockedPortManagementCapab);
 		ReflectionTestHelper.injectPrivateField(openstackRootResourceProvider, serviceProvider, "serviceProvider");
 
 	}
@@ -277,25 +381,34 @@ public class OpenstackRootResourceProviderTest {
 	}
 
 	/**
-	 * Dummy implementation of the {@link FluentIterable} abstract class. This abstract belongs to JClouds client and its used to iterate over
-	 * Resources. This implementation is for testing purposes and contains a list of {@link Server}s.
+	 * Dummy implementation of the {@link FluentIterable} abstract class. This abstract belongs to JClouds client and its used to iterate Resources.
+	 * This implementation is for testing purposes.
 	 * 
 	 * @author Adrian Rosello Rey (i2CAT)
+	 * @param <T>
 	 *
 	 */
-	private class dummyServerFluentIterable extends FluentIterable<Server> {
+	private class dummyFluentIterable<T> extends FluentIterable<T> {
 
-		List<Server>	servers;
+		List<T>	instances;
 
-		public dummyServerFluentIterable(Server... server) {
-			servers = Arrays.asList(server);
+		public dummyFluentIterable(T... object) {
+			instances = Arrays.asList(object);
 		}
 
 		@Override
 		public Iterator iterator() {
-			return servers.iterator();
+			return instances.iterator();
 		}
 
+	}
+
+	private Port buildPortObject(String id, String name, String deviceId) throws SecurityException, IllegalArgumentException, IllegalAccessException {
+		Port port = Port.createBuilder("network-1").deviceId(deviceId).name(name).build();
+		// Neither port object nor port builder does offer methods to set id
+		ReflectionTestHelper.injectPrivateField(port, id, "id");
+
+		return port;
 	}
 
 }

--- a/extensions/openstack/pom.xml
+++ b/extensions/openstack/pom.xml
@@ -24,6 +24,7 @@
 
 	<properties>
 		<jclouds.version>1.8.1</jclouds.version>
+		<network.version>0.0.1-SNAPSHOT</network.version>
 	</properties>
 
 	<dependencyManagement>

--- a/extensions/openstack/src/main/resources/features.xml
+++ b/extensions/openstack/src/main/resources/features.xml
@@ -4,9 +4,12 @@
 	<repository>mvn:org.apache.jclouds.karaf/jclouds-karaf/${jclouds.version}/xml/features</repository>
 	<!-- MQNaaS repository -->
 	<repository>mvn:org.mqnaas/mqnaas/${mqnaas.version}/xml/features</repository>
-
+	<!-- MQNaaS network repository -->
+	<repository>mvn:org.mqnaas.extensions/network/${network.version}/xml/features</repository>
+	
 	<feature name="mqnaas-openstack" version="${project.version}">
 		<feature version="${mqnaas.version}">mqnaas</feature>
+		<feature version="${network.version}">network</feature>
 		<feature version="${project.version}">mqnaas-jclouds</feature>
 
 		<bundle>mvn:org.mqnaas.extensions/jclouds-client-provider/${project.version}</bundle>


### PR DESCRIPTION
In this pull request, the OpenstackRootResource provider capability has been modified to create ports in MQNaaS for each VM port in Openstack. Ports are, of course, created in the IRootResource instance representing the VM the port belongs to.

By using JClouds, we would require to consume the Neutron API in order to get the list of all ports, and then iterate this list to know to which server each one belongs to.

Existing OpenstackRootResourceProvider test needed to be modified to check new feature.

Fixes: [CON-177](http://jira.i2cat.net/browse/CON-177)
