### PR TITLE
Improve dependency injection mechanism

### DIFF
--- a/api.rest/src/main/java/org/mqnaas/api/APIConnector.java
+++ b/api.rest/src/main/java/org/mqnaas/api/APIConnector.java
@@ -72,36 +72,35 @@ public class APIConnector implements IAPIConnector, ServiceListener {
 
 	private static final Logger					log	= LoggerFactory.getLogger(APIConnector.class);
 
-	@DependingOn
+	@DependingOn(core = true)
 	ICoreModelCapability						coreModelCapability;
 
-	@DependingOn
+	@DependingOn(core = true)
 	IObservationService							observationService;
 
-	@DependingOn
+	@DependingOn(core = true)
 	IServiceProvider							serviceProvider;
 
-	@DependingOn
+	@DependingOn(core = true)
 	ICoreProvider								coreProvider;
 
-	@DependingOn
+	@DependingOn(core = true)
 	IRESTAPIProvider							restApiProvider;
 
 	/**
 	 * Depending on IBindingManagement forces this application to be activated only once IBindingManagement is available, which is required to get
 	 * observed services in activate() method.
 	 */
-	@DependingOn
+	@DependingOn(core = true)
 	@SuppressWarnings("unused")
 	IBindingManagement							bindingManagement;
 
-	@DependingOn
+	@DependingOn(core = true)
 	IExecutionService							executionService;
 
-	@DependingOn
+	@DependingOn(core = true)
 	IRootResourceProvider						rootResourceProvider;
 
-	@DependingOn
 	IRootResourceAdministration					rootResourceAdmin;
 
 	private ServiceRegistration<IAPIConnector>	osgiRegistration;

--- a/api.rest/src/main/java/org/mqnaas/api/APIConnector.java
+++ b/api.rest/src/main/java/org/mqnaas/api/APIConnector.java
@@ -92,7 +92,6 @@ public class APIConnector implements IAPIConnector, ServiceListener {
 	 * observed services in activate() method.
 	 */
 	@DependingOn(core = true)
-	@SuppressWarnings("unused")
 	IBindingManagement							bindingManagement;
 
 	@DependingOn(core = true)
@@ -101,6 +100,7 @@ public class APIConnector implements IAPIConnector, ServiceListener {
 	@DependingOn(core = true)
 	IRootResourceProvider						rootResourceProvider;
 
+	@DependingOn(core = true)
 	IRootResourceAdministration					rootResourceAdmin;
 
 	private ServiceRegistration<IAPIConnector>	osgiRegistration;

--- a/clientprovider/src/main/java/org/mqnaas/clientprovider/impl/AbstractProviderFactory.java
+++ b/clientprovider/src/main/java/org/mqnaas/clientprovider/impl/AbstractProviderFactory.java
@@ -54,10 +54,10 @@ public abstract class AbstractProviderFactory<CP> implements ICapability {
 
 	private final Logger			log	= LoggerFactory.getLogger(getClass());
 
-	@DependingOn
+	@DependingOn(core = true)
 	protected ICoreModelCapability	coreModelCapability;
 
-	@DependingOn
+	@DependingOn(core = true)
 	protected IBundleGuard			bundleGuard;
 
 	public static boolean isSupporting(IRootResource resource) {

--- a/core.api/src/main/java/org/mqnaas/core/api/annotations/DependingOn.java
+++ b/core.api/src/main/java/org/mqnaas/core/api/annotations/DependingOn.java
@@ -35,5 +35,5 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.FIELD)
 public @interface DependingOn {
-
+	boolean core() default false;
 }

--- a/core/src/main/java/org/mqnaas/core/impl/ApplicationInstance.java
+++ b/core/src/main/java/org/mqnaas/core/impl/ApplicationInstance.java
@@ -425,8 +425,6 @@ public class ApplicationInstance {
 		 * @return whether the internal state of this instance has changed after this call or not (after the call is using potentialDependency and was
 		 *         not before)
 		 */
-
-		// TODO check this logic!!! mother of god!
 		private Collection<Dependency> resolveDependencies(ApplicationInstance potentialDependency) {
 
 			Collection<Dependency> affected = new ArrayList<Dependency>();

--- a/core/src/main/java/org/mqnaas/core/impl/CoreProvider.java
+++ b/core/src/main/java/org/mqnaas/core/impl/CoreProvider.java
@@ -23,7 +23,9 @@ package org.mqnaas.core.impl;
  */
 
 import org.mqnaas.core.api.ICoreProvider;
+import org.mqnaas.core.api.IResource;
 import org.mqnaas.core.api.IRootResource;
+import org.mqnaas.core.api.Specification;
 import org.mqnaas.core.api.Specification.Type;
 import org.mqnaas.core.api.annotations.Resource;
 import org.mqnaas.core.api.exceptions.ApplicationActivationException;
@@ -67,4 +69,18 @@ public class CoreProvider implements ICoreProvider {
 		return coreResource;
 	}
 
+	/**
+	 * Checks if a given resource is Core resource.
+	 * 
+	 * @param resource
+	 *            {@link IResource} to be checked
+	 * @return true if given resource is Core resource, false otherwise
+	 */
+	public static boolean isCore(IResource resource) {
+		if (IRootResource.class.isAssignableFrom(resource.getClass())) {
+			return ((IRootResource) resource).getDescriptor().getSpecification().getType() == Specification.Type.CORE;
+		}
+
+		return false;
+	}
 }

--- a/core/src/main/java/org/mqnaas/core/impl/RootResourceManagement.java
+++ b/core/src/main/java/org/mqnaas/core/impl/RootResourceManagement.java
@@ -48,7 +48,7 @@ public class RootResourceManagement implements IRootResourceProvider, IRootResou
 
 	private List<IRootResource>			resources	= new ArrayList<IRootResource>();
 
-	@DependingOn
+	@DependingOn(core = true)
 	private IResourceManagementListener	rmListener;
 
 	@Resource

--- a/core/src/main/java/org/mqnaas/core/impl/scheduling/ServiceExecutionScheduler.java
+++ b/core/src/main/java/org/mqnaas/core/impl/scheduling/ServiceExecutionScheduler.java
@@ -65,7 +65,7 @@ public class ServiceExecutionScheduler implements IServiceExecutionScheduler {
 
 	private static final Logger			log	= LoggerFactory.getLogger(ServiceExecutionScheduler.class);
 
-	@DependingOn
+	@DependingOn(core = true)
 	private IExecutionService			executionService;
 
 	private Scheduler					quartzScheduler;

--- a/core/src/main/java/org/mqnaas/core/impl/slicing/SliceAdministration.java
+++ b/core/src/main/java/org/mqnaas/core/impl/slicing/SliceAdministration.java
@@ -50,7 +50,7 @@ import org.slf4j.LoggerFactory;
  */
 public class SliceAdministration implements ISliceAdministration {
 
-	@DependingOn
+	@DependingOn(core = true)
 	private IServiceProvider	serviceProvider;
 
 	@Resource

--- a/core/src/main/java/org/mqnaas/core/impl/slicing/SliceProvider.java
+++ b/core/src/main/java/org/mqnaas/core/impl/slicing/SliceProvider.java
@@ -53,7 +53,7 @@ public class SliceProvider implements ISliceProvider {
 	@Resource
 	private IResource					resource;
 
-	@DependingOn
+	@DependingOn(core = true)
 	private IResourceManagementListener	resourceManagementListener;
 
 	@Override

--- a/core/src/test/java/org/mqnaas/core/impl/dependencies/DependencyManagementTest.java
+++ b/core/src/test/java/org/mqnaas/core/impl/dependencies/DependencyManagementTest.java
@@ -39,10 +39,18 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.mqnaas.core.api.IApplication;
+import org.mqnaas.core.api.ICapability;
+import org.mqnaas.core.api.IRootResource;
+import org.mqnaas.core.api.RootResourceDescriptor;
+import org.mqnaas.core.api.Specification;
+import org.mqnaas.core.api.Specification.Type;
 import org.mqnaas.core.api.exceptions.ApplicationActivationException;
 import org.mqnaas.core.impl.ApplicationInstance;
+import org.mqnaas.core.impl.CapabilityInstance;
+import org.mqnaas.core.impl.RootResource;
 import org.mqnaas.core.impl.dependencies.samples.IApp;
 import org.mqnaas.core.impl.dummy.DummyExecutionService;
+import org.mqnaas.general.test.helpers.reflection.ReflectionTestHelper;
 
 /**
  * 
@@ -82,14 +90,14 @@ public class DependencyManagementTest {
 	}
 
 	@Before
-	public void initDepManager() {
+	public void initDepManager() throws SecurityException, IllegalArgumentException, IllegalAccessException, InstantiationException {
 		depManager = new DependencyManagement();
 		// add execution service that is required for any ApplicationInstance
 		depManager.addApplicationInTheSystem(createApp(new DummyExecutionService()));
 	}
 
 	@Test
-	public void addedApplicationsAreInSystem() {
+	public void addedApplicationsAreInSystem() throws SecurityException, IllegalArgumentException, IllegalAccessException, InstantiationException {
 
 		// add application instances to system
 		List<ApplicationInstance> added = new ArrayList<ApplicationInstance>();
@@ -107,7 +115,8 @@ public class DependencyManagementTest {
 	}
 
 	@Test
-	public void removedApplicationsAreNotInSystem() {
+	public void removedApplicationsAreNotInSystem() throws SecurityException, IllegalArgumentException, IllegalAccessException,
+			InstantiationException {
 
 		// add application instances to system
 		List<ApplicationInstance> added = new ArrayList<ApplicationInstance>();
@@ -126,7 +135,8 @@ public class DependencyManagementTest {
 	}
 
 	@Test
-	public void newcommingAppIsResolvedWithExistingApps() {
+	public void newcommingAppIsResolvedWithExistingApps() throws SecurityException, IllegalArgumentException, IllegalAccessException,
+			InstantiationException {
 
 		for (IApp iapp : apps) {
 			ApplicationInstance app = createApp(iapp);
@@ -163,7 +173,8 @@ public class DependencyManagementTest {
 	}
 
 	@Test
-	public void newcommingAppIsUsedToResolveExistingApps() {
+	public void newcommingAppIsUsedToResolveExistingApps() throws SecurityException, IllegalArgumentException, IllegalAccessException,
+			InstantiationException {
 
 		for (IApp iapp : apps) {
 			ApplicationInstance app = createApp(iapp);
@@ -193,7 +204,8 @@ public class DependencyManagementTest {
 	}
 
 	@Test
-	public void appWithAllDependenciesAssignedIsResolved() {
+	public void appWithAllDependenciesAssignedIsResolved() throws SecurityException, IllegalArgumentException, IllegalAccessException,
+			InstantiationException {
 
 		for (IApp iapp : apps) {
 			ApplicationInstance toAdd = createApp(iapp);
@@ -222,7 +234,8 @@ public class DependencyManagementTest {
 	}
 
 	@Test
-	public void appWithAllDependencyChainResolvedIsActivated() {
+	public void appWithAllDependencyChainResolvedIsActivated() throws SecurityException, IllegalArgumentException, IllegalAccessException,
+			InstantiationException {
 		for (IApp iapp : apps) {
 			ApplicationInstance toAdd = createApp(iapp);
 			depManager.addApplicationInTheSystem(toAdd);
@@ -237,7 +250,8 @@ public class DependencyManagementTest {
 	}
 
 	@Test
-	public void removedAppsAreNotInjectedAsDependencies() {
+	public void removedAppsAreNotInjectedAsDependencies() throws SecurityException, IllegalArgumentException, IllegalAccessException,
+			InstantiationException {
 
 		for (IApp iapp : apps) {
 			ApplicationInstance toAdd = createApp(iapp);
@@ -255,7 +269,8 @@ public class DependencyManagementTest {
 	}
 
 	@Test
-	public void appsUsingDependencyAreDeactivatedWhenDependencyIsRemoved() {
+	public void appsUsingDependencyAreDeactivatedWhenDependencyIsRemoved() throws SecurityException, IllegalArgumentException,
+			IllegalAccessException, InstantiationException {
 
 		for (IApp iapp : apps) {
 			ApplicationInstance toAdd = createApp(iapp);
@@ -282,7 +297,8 @@ public class DependencyManagementTest {
 	}
 
 	@Test
-	public void appsUsingDependencyAreNoLongerResolvedWhenDependencyIsRemoved() {
+	public void appsUsingDependencyAreNoLongerResolvedWhenDependencyIsRemoved() throws SecurityException, IllegalArgumentException,
+			IllegalAccessException, InstantiationException {
 
 		for (IApp iapp : apps) {
 			ApplicationInstance toAdd = createApp(iapp);
@@ -310,7 +326,8 @@ public class DependencyManagementTest {
 	}
 
 	@Test
-	public void appsWithRemovedAppInDependencyChainAreDeactivated() {
+	public void appsWithRemovedAppInDependencyChainAreDeactivated() throws SecurityException, IllegalArgumentException, IllegalAccessException,
+			InstantiationException {
 
 		for (IApp iapp : apps) {
 			ApplicationInstance toAdd = createApp(iapp);
@@ -335,7 +352,8 @@ public class DependencyManagementTest {
 	}
 
 	@Test
-	public void iApplicationActivateCalledDuringAppActivation() {
+	public void iApplicationActivateCalledDuringAppActivation() throws SecurityException, IllegalArgumentException, IllegalAccessException,
+			InstantiationException {
 
 		for (IApp iapp : apps) {
 			ApplicationInstance toAdd = createApp(iapp);
@@ -355,7 +373,8 @@ public class DependencyManagementTest {
 	}
 
 	@Test
-	public void iApplicationDectivateCalledDuringAppDeactivation() {
+	public void iApplicationDectivateCalledDuringAppDeactivation() throws SecurityException, IllegalArgumentException, IllegalAccessException,
+			InstantiationException {
 
 		for (IApp iapp : apps) {
 			ApplicationInstance toAdd = createApp(iapp);
@@ -399,7 +418,8 @@ public class DependencyManagementTest {
 	}
 
 	@Test
-	public void scenarioIsAllActiveWhenCompletelyResolved() {
+	public void scenarioIsAllActiveWhenCompletelyResolved() throws SecurityException, IllegalArgumentException, IllegalAccessException,
+			InstantiationException {
 
 		Set<Class<? extends IApplication>> implemented = new HashSet<Class<? extends IApplication>>();
 		Set<Class<? extends IApplication>> required = new HashSet<Class<? extends IApplication>>();
@@ -426,7 +446,8 @@ public class DependencyManagementTest {
 	}
 
 	@Test
-	public void resolveWithExistingImplementationsWhenDependencyIsRemoved() {
+	public void resolveWithExistingImplementationsWhenDependencyIsRemoved() throws SecurityException, IllegalArgumentException,
+			IllegalAccessException, InstantiationException {
 
 		for (IApp iapp : apps) {
 			ApplicationInstance toAdd = createApp(iapp);
@@ -483,9 +504,19 @@ public class DependencyManagementTest {
 
 	}
 
-	private ApplicationInstance createApp(IApplication app) {
-		ApplicationInstance ai = new ApplicationInstance(app.getClass(), app);
-		return ai;
+	private ApplicationInstance createApp(IApplication app) throws SecurityException, IllegalArgumentException, IllegalAccessException,
+			InstantiationException {
+		if (ICapability.class.isAssignableFrom(app.getClass())) {
+			// safe cast, it has been checked previously
+			@SuppressWarnings("unchecked")
+			CapabilityInstance ci = new CapabilityInstance((Class<? extends ICapability>) app.getClass(), (ICapability) app);
+			ReflectionTestHelper.injectPrivateField(ci, createDummyCoreResource(), "resource");
+			return ci;
+
+		} else {
+			ApplicationInstance ai = new ApplicationInstance(app.getClass(), app);
+			return ai;
+		}
 	}
 
 	private ApplicationInstance createAppFailingOnActivate() {
@@ -525,4 +556,9 @@ public class DependencyManagementTest {
 		}
 	}
 
+	private static IRootResource createDummyCoreResource() throws InstantiationException, IllegalAccessException {
+		Specification specification = new Specification(Type.CORE);
+		RootResourceDescriptor descriptor = RootResourceDescriptor.create(specification);
+		return new RootResource(descriptor);
+	}
 }

--- a/core/src/test/java/org/mqnaas/core/impl/dependency_injection/DependencyInjectionTests.java
+++ b/core/src/test/java/org/mqnaas/core/impl/dependency_injection/DependencyInjectionTests.java
@@ -31,7 +31,6 @@ import javax.inject.Inject;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mqnaas.core.api.Endpoint;
@@ -126,7 +125,6 @@ public class DependencyInjectionTests {
 		rootResourceMgmt.removeRootResource(resourceAInstance3);
 	}
 
-	@Ignore
 	@Test
 	public void rootResourceProviderInjectionTest() throws IllegalArgumentException, IllegalAccessException, CapabilityNotFoundException {
 		// get ISampleCapability instances of each resourceA instance
@@ -135,12 +133,9 @@ public class DependencyInjectionTests {
 		ISampleCapability resourceA3SampleCapabilityInstance = serviceProvider.getCapabilityInstance(resourceAInstance3, ISampleCapability.class);
 
 		// get IRootResourceProvider instances of each resourceA instance
-		IRootResourceProvider resourceA1RootResourceProviderInstance = serviceProvider.getCapabilityInstance(resourceAInstance1,
-				IRootResourceProvider.class);
-		IRootResourceProvider resourceA2RootResourceProviderInstance = serviceProvider.getCapabilityInstance(resourceAInstance2,
-				IRootResourceProvider.class);
-		IRootResourceProvider resourceA3RootResourceProviderInstance = serviceProvider.getCapabilityInstance(resourceAInstance3,
-				IRootResourceProvider.class);
+		IRootResourceProvider resourceA1RootResourceProviderInstance = serviceProvider.getCapability(resourceAInstance1, IRootResourceProvider.class);
+		IRootResourceProvider resourceA2RootResourceProviderInstance = serviceProvider.getCapability(resourceAInstance2, IRootResourceProvider.class);
+		IRootResourceProvider resourceA3RootResourceProviderInstance = serviceProvider.getCapability(resourceAInstance3, IRootResourceProvider.class);
 
 		// get injected IRootResourceProvider instances of each IRootResourceProvider instance
 		IRootResourceProvider resourceA1RootResourceProviderInjectedInstance = getPrivateField(resourceA1SampleCapabilityInstance,
@@ -150,10 +145,10 @@ public class DependencyInjectionTests {
 		IRootResourceProvider resourceA3RootResourceProviderInjectedInstance = getPrivateField(resourceA3SampleCapabilityInstance,
 				IRootResourceProvider.class);
 
-		// assert instance equality
-		Assert.assertEquals("Instances should be equals", resourceA1RootResourceProviderInstance, resourceA1RootResourceProviderInjectedInstance);
-		Assert.assertEquals("Instances should be equals", resourceA2RootResourceProviderInstance, resourceA2RootResourceProviderInjectedInstance);
-		Assert.assertEquals("Instances should be equals", resourceA3RootResourceProviderInstance, resourceA3RootResourceProviderInjectedInstance);
+		// assert instance equality (using class instance equality due to Proxies usage)
+		Assert.assertTrue("Instances should be equals", resourceA1RootResourceProviderInstance == resourceA1RootResourceProviderInjectedInstance);
+		Assert.assertTrue("Instances should be equals", resourceA2RootResourceProviderInstance == resourceA2RootResourceProviderInjectedInstance);
+		Assert.assertTrue("Instances should be equals", resourceA3RootResourceProviderInstance == resourceA3RootResourceProviderInjectedInstance);
 	}
 
 	private IRootResource createRootResource(Specification.Type resourceType, String resourceModel) throws InstantiationException,

--- a/extensions/modelreader/modelreader-capability/src/main/java/org/mqnaas/extensions/modelreader/impl/ResourceModelReader.java
+++ b/extensions/modelreader/modelreader-capability/src/main/java/org/mqnaas/extensions/modelreader/impl/ResourceModelReader.java
@@ -55,10 +55,10 @@ public class ResourceModelReader implements IResourceModelReader {
 
 	private static final Logger	log	= LoggerFactory.getLogger(ResourceModelReader.class);
 
-	@DependingOn
+	@DependingOn(core = true)
 	IServiceProvider			serviceProvider;
 
-	@DependingOn
+	@DependingOn(core = true)
 	IExecutionService			serviceExecution;
 
 	@Resource

--- a/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/NetworkManagement.java
+++ b/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/NetworkManagement.java
@@ -78,10 +78,10 @@ public class NetworkManagement implements IRequestBasedNetworkManagement {
 		return type == Type.NETWORK && !StringUtils.equals(rootResource.getDescriptor().getSpecification().getModel(), "nitos");
 	}
 
-	@DependingOn
+	@DependingOn(core = true)
 	private IResourceManagementListener		resourceManagementListener;
 
-	@DependingOn
+	@DependingOn(core = true)
 	IServiceProvider						serviceProvider;
 
 	@Resource

--- a/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/request/RequestResourceMapping.java
+++ b/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/request/RequestResourceMapping.java
@@ -58,7 +58,7 @@ public class RequestResourceMapping implements IRequestResourceMapping {
 	@Resource
 	IResource							resource;
 
-	@DependingOn
+	@DependingOn(core = true)
 	IServiceProvider					serviceProvider;
 
 	private Map<IResource, IResource>	mapping;

--- a/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/reservation/ReservationManagement.java
+++ b/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/reservation/ReservationManagement.java
@@ -80,10 +80,10 @@ public class ReservationManagement implements IReservationManagement, IReservati
 	@DependingOn
 	IReservationPerformer								reservationPerformer;
 
-	@DependingOn
+	@DependingOn(core = true)
 	IServiceProvider									serviceProvider;
 
-	@DependingOn
+	@DependingOn(core = true)
 	IServiceExecutionScheduler							serviceExecutionScheduler;
 
 	public static boolean isSupporting(IRootResource rootResource) {

--- a/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/reservation/ReservationPerformer.java
+++ b/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/reservation/ReservationPerformer.java
@@ -59,10 +59,10 @@ public class ReservationPerformer implements IReservationPerformer {
 
 	private static final Logger	log	= LoggerFactory.getLogger(ReservationPerformer.class);
 
-	@DependingOn
+	@DependingOn(core = true)
 	IServiceProvider			serviceProvider;
 
-	@DependingOn
+	@DependingOn(core = true)
 	IServiceExecutionScheduler	serviceExecutionScheduler;
 
 	@Resource

--- a/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/topology/link/LinkAdministration.java
+++ b/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/topology/link/LinkAdministration.java
@@ -40,7 +40,7 @@ public class LinkAdministration implements ILinkAdministration {
 
 	private IResource					srcPort, destPort;
 
-	@DependingOn
+	@DependingOn(core = true)
 	private IResourceManagementListener	resourceManagementListener;
 
 	@Override

--- a/extensions/odl/capabilities/src/main/java/org/mqnaas/extensions/odl/capabilities/flows/ODLFlowManagement.java
+++ b/extensions/odl/capabilities/src/main/java/org/mqnaas/extensions/odl/capabilities/flows/ODLFlowManagement.java
@@ -37,16 +37,16 @@ import org.mqnaas.extensions.odl.helium.flowprogrammer.model.FlowConfig;
 import org.mqnaas.extensions.odl.helium.flowprogrammer.model.FlowConfigs;
 
 public class ODLFlowManagement implements IFlowManagement {
-	
+
 	@Resource
-	IResource	network;
-	
-	@DependingOn
+	IResource							network;
+
+	@DependingOn(core = true)
 	private IAPIClientProviderFactory	apiProviderFactory;
-	
+
 	public static boolean isSupporting(IRootResource rootResource) {
 		Type type = rootResource.getDescriptor().getSpecification().getType();
-		
+
 		return type == Type.NETWORK && StringUtils.equals(rootResource.getDescriptor().getSpecification().getModel(), "odl");
 	}
 
@@ -55,7 +55,7 @@ public class ODLFlowManagement implements IFlowManagement {
 		// fail fast when client is not available
 		try {
 			getFlowProgrammerClient();
-		} catch (Exception e){
+		} catch (Exception e) {
 			throw new ApplicationActivationException("Required client is unavailable", e);
 		}
 	}
@@ -73,7 +73,7 @@ public class ODLFlowManagement implements IFlowManagement {
 	public FlowConfigs getFlows(String dpid) throws IllegalStateException, Exception {
 		return getFlowProgrammerClient().getStaticFlows(dpid);
 	}
-	
+
 	@Override
 	public void addFlow(FlowConfig flow) throws IllegalStateException, Exception {
 		getFlowProgrammerClient().addOrModifyFlow(flow, flow.getNode().getId(), flow.getName());
@@ -83,14 +83,15 @@ public class ODLFlowManagement implements IFlowManagement {
 	public void deleteFlow(String dpid, String flowName) throws IllegalStateException, Exception {
 		getFlowProgrammerClient().deleteFlow(dpid, flowName);
 	}
-	
+
 	/**
 	 * 
 	 * @return
-	 * @throws IllegalStateException when client is not available
+	 * @throws IllegalStateException
+	 *             when client is not available
 	 */
 	private IOpenDaylightFlowProgrammerNorthbound getFlowProgrammerClient() throws IllegalStateException {
-		
+
 		try {
 			return apiProviderFactory.getAPIProvider(ICXFAPIProvider.class)
 					.getAPIClient(network, IOpenDaylightFlowProgrammerNorthbound.class, null);

--- a/extensions/odl/capabilities/src/main/java/org/mqnaas/extensions/odl/capabilities/impl/ODLRootResourceProvider.java
+++ b/extensions/odl/capabilities/src/main/java/org/mqnaas/extensions/odl/capabilities/impl/ODLRootResourceProvider.java
@@ -53,12 +53,12 @@ import org.mqnaas.core.impl.AttributeStore;
 import org.mqnaas.core.impl.RootResource;
 import org.mqnaas.extensions.odl.client.helium.topology.api.IOpenDaylightTopologyNorthbound;
 import org.mqnaas.extensions.odl.client.switchnorthbound.ISwitchNorthboundAPI;
+import org.mqnaas.extensions.odl.helium.switchmanager.model.Node.NodeType;
 import org.mqnaas.extensions.odl.helium.switchmanager.model.NodeConnector;
 import org.mqnaas.extensions.odl.helium.switchmanager.model.NodeConnectorProperties;
 import org.mqnaas.extensions.odl.helium.switchmanager.model.NodeConnectors;
 import org.mqnaas.extensions.odl.helium.switchmanager.model.NodeProperties;
 import org.mqnaas.extensions.odl.helium.switchmanager.model.Nodes;
-import org.mqnaas.extensions.odl.helium.switchmanager.model.Node.NodeType;
 import org.mqnaas.extensions.odl.helium.topology.model.EdgeProperty;
 import org.mqnaas.extensions.odl.helium.topology.model.Topology;
 import org.mqnaas.network.api.topology.link.ILinkAdministration;
@@ -92,13 +92,13 @@ public class ODLRootResourceProvider implements IRootResourceProvider {
 	@Resource
 	IRootResource							resource;
 
-	@DependingOn
+	@DependingOn(core = true)
 	IServiceProvider						serviceProvider;
 
-	@DependingOn
+	@DependingOn(core = true)
 	IAPIClientProviderFactory				apiProviderFactory;
 
-	@DependingOn
+	@DependingOn(core = true)
 	IResourceManagementListener				rmListener;
 
 	@DependingOn

--- a/extensions/openstack/openstack-impl/src/main/java/org/mqnaas/extensions/openstack/capabilities/impl/OpenstackRootResourceProvider.java
+++ b/extensions/openstack/openstack-impl/src/main/java/org/mqnaas/extensions/openstack/capabilities/impl/OpenstackRootResourceProvider.java
@@ -81,16 +81,16 @@ public class OpenstackRootResourceProvider implements IRootResourceProvider {
 
 	private NovaApi						novaClient;
 
-	@DependingOn
+	@DependingOn(core = true)
 	IResourceManagementListener			resourceManagementListener;
 
 	@DependingOn
 	IJCloudsNovaClientProvider			jcloudsClientProvider;
 
-	@DependingOn
+	@DependingOn(core = true)
 	IResourceManagementListener			rmListener;
 
-	@DependingOn
+	@DependingOn(core = true)
 	IServiceProvider					serviceProvider;
 
 	@Resource


### PR DESCRIPTION
Improve the algorithm to decide which `IApplication`/`ICapability` is injected for each `DependingOn` annotated field. Now there is a `core` parameter to be used to denote the necessity of injecting core resource associated capability instances. Then the dependency injection mechanism perform these actions for `DependingOn` annotated fields in `IApplication`'s and `ICapability`'s:

* It injects a core resource capability instance for `ICapability`'s if `core` parameter is true or same resource capability instance if not.
* It injects first available application for pure `IApplication`'s.

As a consequence there are cases when it is not possible using `DependningOn` annotation:

* An `IApplication` with an `ICapability` field annotated with `DependningOn` annotation with `core` parameter equals to false (default value). Like this:

```java
class App implements IApplication {

  @DependingOn
  CapabilityA capabilityA;

  ...
}
```
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;where `CapabilityA` implements `ICapability`.

`IApplication`'s have not associated resource, then it is not possible to resolve `App` resource and find associated `CapabilityA` instance.

* An `IApplication` or an `ICapability` with an `ICapability` field annotated with `DependningOn` annotation with `core` parameter equals to true. Like one of these:
<table>
  <tr>
    <td>
<pre lang="java">
class App implements IApplication {

  @DependingOn(core = true)
  ApplicationA appA;

  ...
}
</pre>
    </td>
    <td>
<pre lang="java">
class Cap implements ICapability {

  @DependingOn(core = true)
  ApplicationA appA;

  ...
}
</pre>
    </td>
  </tr>
</table>

&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;where `ApplicationA` implements `IApplication`.

There are not core resource associated `IApplication`'s. For this reason, it will not be possible injecting `IApplication` annotated with `DependingOn` annotation with `core` parameter equals to true.

For these three cases, an error will be explicitly launched in the logs, and the bad formed `IApplication`'s and `ICapability` will not be initialized, but the entire system will continue working.


This pull requests adapts dependency injection mechanism and adds `core` parameter where necessary. Moreover, it solve some tests issues and activates `DependencyInjectionTests`. Changes are needed in extensions using `DependingOn` annotation.