### PR TITLE
Feature/model reader with openstack

### DIFF
--- a/extensions/modelreader/modelreader-capability/pom.xml
+++ b/extensions/modelreader/modelreader-capability/pom.xml
@@ -34,6 +34,11 @@
 			<groupId>org.mqnaas.extensions</groupId>
 			<artifactId>odl.capabilities</artifactId>
 		</dependency>
+		<!-- Openstack modules -->
+		<dependency>
+			<groupId>org.mqnaas.extensions</groupId>
+			<artifactId>openstack-api</artifactId>
+		</dependency>
 		<!-- Testing libraries -->
 		<dependency>
 			<groupId>junit</groupId>

--- a/extensions/modelreader/modelreader-capability/src/main/java/org/mqnaas/extensions/modelreader/api/HostInformationWrapper.java
+++ b/extensions/modelreader/modelreader-capability/src/main/java/org/mqnaas/extensions/modelreader/api/HostInformationWrapper.java
@@ -37,7 +37,7 @@ import org.mqnaas.core.api.Specification.Type;
  * @author Adrián Roselló Rey (i2CAT)
  *
  */
-@XmlType(name = "hostInformation")
+@XmlType(name = "hostInformation", propOrder = { "numberOfCPUs", "memorySize", "diskSize", "swapSize" })
 @XmlAccessorType(XmlAccessType.FIELD)
 public class HostInformationWrapper implements Serializable {
 

--- a/extensions/modelreader/modelreader-capability/src/main/java/org/mqnaas/extensions/modelreader/api/HostInformationWrapper.java
+++ b/extensions/modelreader/modelreader-capability/src/main/java/org/mqnaas/extensions/modelreader/api/HostInformationWrapper.java
@@ -1,0 +1,133 @@
+package org.mqnaas.extensions.modelreader.api;
+
+/*
+ * #%L
+ * MQNaaS :: Generic Model Reader
+ * %%
+ * Copyright (C) 2007 - 2015 Fundació Privada i2CAT, Internet i
+ * 			Innovació a Catalunya
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import java.io.Serializable;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlType;
+
+import org.mqnaas.core.api.Specification.Type;
+
+/**
+ * <p>
+ * Wrapper class containing the main hardware information of a {@link Type#HOST} resource.
+ * </p>
+ * 
+ * @author Adrián Roselló Rey (i2CAT)
+ *
+ */
+@XmlType(name = "hostInformation")
+@XmlAccessorType(XmlAccessType.FIELD)
+public class HostInformationWrapper implements Serializable {
+
+	private static final long	serialVersionUID	= 7615703041852542009L;
+
+	private int					numberOfCPUs;
+	private int					memorySize;
+	private int					diskSize;
+	private String				swapSize;
+
+	public HostInformationWrapper() {
+
+	}
+
+	public HostInformationWrapper(int numberOfCPUs, int memorySize, int diskSize, String swap) {
+		this.numberOfCPUs = numberOfCPUs;
+		this.memorySize = memorySize;
+		this.diskSize = diskSize;
+		this.swapSize = swap;
+	}
+
+	public int getNumberOfCPUs() {
+		return numberOfCPUs;
+	}
+
+	public void setNumberOfCPUs(int numberOfCPUs) {
+		this.numberOfCPUs = numberOfCPUs;
+	}
+
+	public int getMemorySize() {
+		return memorySize;
+	}
+
+	public void setMemorySize(int memorySize) {
+		this.memorySize = memorySize;
+	}
+
+	public int getDiskSize() {
+		return diskSize;
+	}
+
+	public void setDiskSize(int diskSize) {
+		this.diskSize = diskSize;
+	}
+
+	public String getSwapSize() {
+		return swapSize;
+	}
+
+	public void setSwapSize(String swapSize) {
+		this.swapSize = swapSize;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + diskSize;
+		result = prime * result + memorySize;
+		result = prime * result + numberOfCPUs;
+		result = prime * result + ((swapSize == null) ? 0 : swapSize.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		HostInformationWrapper other = (HostInformationWrapper) obj;
+		if (diskSize != other.diskSize)
+			return false;
+		if (memorySize != other.memorySize)
+			return false;
+		if (numberOfCPUs != other.numberOfCPUs)
+			return false;
+		if (swapSize == null) {
+			if (other.swapSize != null)
+				return false;
+		} else if (!swapSize.equals(other.swapSize))
+			return false;
+		return true;
+	}
+
+	@Override
+	public String toString() {
+		return "HostInformationWrapper [numberOfCPUs=" + numberOfCPUs + ", memorySize=" + memorySize + ", diskSize=" + diskSize + ", swap=" + swapSize + "]";
+	}
+
+}

--- a/extensions/modelreader/modelreader-capability/src/main/java/org/mqnaas/extensions/modelreader/api/ResourceModelWrapper.java
+++ b/extensions/modelreader/modelreader-capability/src/main/java/org/mqnaas/extensions/modelreader/api/ResourceModelWrapper.java
@@ -40,7 +40,8 @@ import org.mqnaas.extensions.odl.helium.flowprogrammer.model.FlowConfigs;
  * Wrapper class of resources, containing the tree of {@link IResource}s representing the model of a resource.
  * </p>
  * 
- * FIXME It contains specific openflow information. This class should be modified when we implement a generic way to specify the state of a resource.
+ * FIXME It contains specific openflow information, as well as specific information for hosts. This class should be modified when we implement a
+ * generic way to specify the state of a resource.
  * 
  * @author Adrián Roselló Rey (i2CAT)
  *
@@ -62,7 +63,9 @@ public class ResourceModelWrapper {
 
 	private FlowConfigs					configuredRules;
 
-	// constructor withour arguments, required by JAXB
+	private HostInformationWrapper		hostInformation;
+
+	// constructor without arguments, required by JAXB
 	ResourceModelWrapper() {
 	}
 
@@ -112,12 +115,21 @@ public class ResourceModelWrapper {
 		this.configuredRules = configuredRules;
 	}
 
+	public HostInformationWrapper getHostInformation() {
+		return hostInformation;
+	}
+
+	public void setHostInformation(HostInformationWrapper hostInformation) {
+		this.hostInformation = hostInformation;
+	}
+
 	@Override
 	public int hashCode() {
 		final int prime = 31;
 		int result = 1;
 		result = prime * result + ((attributes == null) ? 0 : attributes.hashCode());
 		result = prime * result + ((configuredRules == null) ? 0 : configuredRules.hashCode());
+		result = prime * result + ((hostInformation == null) ? 0 : hostInformation.hashCode());
 		result = prime * result + ((id == null) ? 0 : id.hashCode());
 		result = prime * result + ((resources == null) ? 0 : resources.hashCode());
 		result = prime * result + ((type == null) ? 0 : type.hashCode());
@@ -143,6 +155,11 @@ public class ResourceModelWrapper {
 				return false;
 		} else if (!configuredRules.equals(other.configuredRules))
 			return false;
+		if (hostInformation == null) {
+			if (other.hostInformation != null)
+				return false;
+		} else if (!hostInformation.equals(other.hostInformation))
+			return false;
 		if (id == null) {
 			if (other.id != null)
 				return false;
@@ -163,7 +180,7 @@ public class ResourceModelWrapper {
 
 	@Override
 	public String toString() {
-		return "ResourceModelWrapper [id=" + id + ", type=" + type + ", attributes=" + attributes + ", resources=" + resources + ", configuredRules=" + configuredRules + "]";
+		return "ResourceModelWrapper [id=" + id + ", type=" + type + ", attributes=" + attributes + ", resources=" + resources + ", configuredRules=" + configuredRules + ", hostInformation=" + hostInformation + "]";
 	}
 
 }

--- a/extensions/modelreader/pom.xml
+++ b/extensions/modelreader/pom.xml
@@ -16,6 +16,7 @@
 	<properties>	
 		<network.version>0.0.1-SNAPSHOT</network.version>
 		<odl.version>0.0.1-SNAPSHOT</odl.version>
+		<openstack.version>0.0.1-SNAPSHOT</openstack.version>
 	</properties>
 
 	<modules>
@@ -30,6 +31,12 @@
 				<groupId>org.mqnaas.extensions</groupId>
 				<artifactId>modelreader-capability</artifactId>
 				<version>${project.version}</version>
+			</dependency>
+			<!-- Openstack modules -->
+			<dependency>
+				<groupId>org.mqnaas.extensions</groupId>
+				<artifactId>openstack-api</artifactId>
+				<version>${openstack.version}</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/extensions/modelreader/src/main/resources/features.xml
+++ b/extensions/modelreader/src/main/resources/features.xml
@@ -7,12 +7,15 @@
 	<repository>mvn:org.mqnaas.extensions/network/${network.version}/xml/features</repository>
 	<!-- MQNaaS ODL repository -->
 	<repository>mvn:org.mqnaas.extensions/odl/${odl.version}/xml/features</repository>
+	<!-- MQNaaS Openstack repository -->
+	<repository>mvn:org.mqnaas.extensions/openstack/${openstack.version}/xml/features</repository>
 	
 	<feature name="mqnaas-modelreader" version="${project.version}">
 
 	    <feature version="${mqnaas.version}">mqnaas</feature>	    
 	    <feature version="${network.version}">network</feature>	    
-	  	<feature version="${odl.version}">odl</feature>	    
+	  	<feature version="${odl.version}">odl</feature>	   
+	  	<feature version="${openstack.version}">mqnaas-openstack</feature>	    	  	 
 	    
 		<bundle>mvn:org.mqnaas.extensions/modelreader-capability/${project.version}</bundle>
 

--- a/extensions/openstack/openstack-impl/src/main/java/org/mqnaas/extensions/openstack/capabilities/impl/OpenstackRootResourceProvider.java
+++ b/extensions/openstack/openstack-impl/src/main/java/org/mqnaas/extensions/openstack/capabilities/impl/OpenstackRootResourceProvider.java
@@ -94,7 +94,7 @@ public class OpenstackRootResourceProvider implements IRootResourceProvider {
 	@DependingOn(core = true)
 	IResourceManagementListener			resourceManagementListener;
 
-	@DependingOn
+	@DependingOn(core = true)
 	IResourceManagementListener			rmListener;
 
 	@DependingOn(core = true)

--- a/extensions/openstack/openstack-impl/src/test/java/org/mqnaas/extensions/openstack/capabilities/impl/OpenstackHostAdministrationTest.java
+++ b/extensions/openstack/openstack-impl/src/test/java/org/mqnaas/extensions/openstack/capabilities/impl/OpenstackHostAdministrationTest.java
@@ -31,6 +31,7 @@ import org.jclouds.openstack.nova.v2_0.NovaApi;
 import org.jclouds.openstack.nova.v2_0.domain.Flavor;
 import org.jclouds.openstack.nova.v2_0.domain.Server;
 import org.jclouds.openstack.nova.v2_0.domain.Server.Status;
+import org.jclouds.openstack.nova.v2_0.features.FlavorApi;
 import org.jclouds.openstack.nova.v2_0.features.ServerApi;
 import org.junit.Assert;
 import org.junit.Before;
@@ -104,7 +105,7 @@ public class OpenstackHostAdministrationTest {
 	IJCloudsNovaClientProvider	mockedJcloudsClientProvider;
 	NovaApi						mockedNovaApi;
 	ServerApi					mockedServerApi;
-
+	FlavorApi					mockedFlavorApi;
 	/**
 	 * Objects returned by mocked capabilities/clients.
 	 */
@@ -195,8 +196,12 @@ public class OpenstackHostAdministrationTest {
 
 		mockedNovaApi = PowerMockito.mock(NovaApi.class);
 		mockedServerApi = PowerMockito.mock(ServerApi.class);
+		mockedFlavorApi = PowerMockito.mock(FlavorApi.class);
 		PowerMockito.when(mockedNovaApi.getServerApiForZone(Mockito.eq(ZONE))).thenReturn(mockedServerApi);
+		PowerMockito.when(mockedNovaApi.getFlavorApiForZone(Mockito.eq(ZONE))).thenReturn(mockedFlavorApi);
+
 		PowerMockito.when(mockedServerApi.get(Mockito.eq(HOST_EXT_ID))).thenReturn(server);
+		PowerMockito.when(mockedFlavorApi.get(Mockito.eq(flavor.getId()))).thenReturn(flavor);
 
 		// mock jCloudsClientProvider and inject it in capability.
 


### PR DESCRIPTION
With this pull request, model-reader capabiltiy is able to return information about openstack VMs.

As previous implementation of ODL, the model-reader capability contains openstack specific information, until we find a way to generically print the state of a capability.

Fixes taks: http://jira.i2cat.net/browse/CON-178
