### PR TITLE
Fix null access when no @ListResources method available.

### DIFF
--- a/api.rest/src/main/java/org/mqnaas/api/translators/ResourceTranslator.java
+++ b/api.rest/src/main/java/org/mqnaas/api/translators/ResourceTranslator.java
@@ -109,11 +109,13 @@ public class ResourceTranslator implements Translator {
 
 		private List<IResource> getResources() {
 			try {
-				// The contract of the list method is, that it return a list of resources and has no parameters.
-				// TODO Document the contract
-				@SuppressWarnings("unchecked")
-				List<IResource> resources = (List<IResource>) listMethod.invoke(implementor, new Object[0]);
-				return resources;
+				if (listMethod != null) {
+					// The contract of the list method is, that it return a list of resources and has no parameters.
+					// TODO Document the contract
+					@SuppressWarnings("unchecked")
+					List<IResource> resources = (List<IResource>) listMethod.invoke(implementor, new Object[0]);
+					return resources;
+				}
 			} catch (IllegalArgumentException e) {
 				// TODO Rethink the handling of the exceptions caught..
 				e.printStackTrace();


### PR DESCRIPTION
This patch avoids a NullPointerException when ResourceTranslator
attempts to use a Resolver without listMethod.

This behaviour was noticed issuing following request:
http://localhost:9000/mqnaas/IRootResourceAdministration/RESOURCE_ID
Which returned Error 500

The same request now has the same behaviour that
http://localhost:9000/mqnaas/IRootResourceProvider/UNKNOWN_ID