### PR TITLE
Use correct attribute to store external ports names.

### DIFF
--- a/extensions/network/itests/src/test/java/org/mqnaas/extensions/network/itests/NetworkManagementTest.java
+++ b/extensions/network/itests/src/test/java/org/mqnaas/extensions/network/itests/NetworkManagementTest.java
@@ -54,7 +54,6 @@ import org.mqnaas.network.api.exceptions.NetworkCreationException;
 import org.mqnaas.network.api.request.Period;
 import org.mqnaas.network.impl.Link;
 import org.mqnaas.network.impl.Network;
-import org.mqnaas.network.impl.NetworkManagement;
 import org.mqnaas.network.impl.NetworkSubResource;
 import org.mqnaas.network.impl.PortResourceWrapper;
 import org.mqnaas.network.impl.request.Request;
@@ -149,10 +148,10 @@ public class NetworkManagementTest {
 		physicalPort22 = new PortResourceWrapper(physicalSwitch2.createPort(), serviceProvider);
 
 		// map ports to external ids
-		physicalPort11.setAttribute(NetworkManagement.PORT_INTERNAL_ID_ATTRIBUTE, PHYSICAL_PORT_11_EXTERNAL_ID);
-		physicalPort12.setAttribute(NetworkManagement.PORT_INTERNAL_ID_ATTRIBUTE, PHYSICAL_PORT_12_EXTERNAL_ID);
-		physicalPort21.setAttribute(NetworkManagement.PORT_INTERNAL_ID_ATTRIBUTE, PHYSICAL_PORT_21_EXTERNAL_ID);
-		physicalPort22.setAttribute(NetworkManagement.PORT_INTERNAL_ID_ATTRIBUTE, PHYSICAL_PORT_22_EXTERNAL_ID);
+		physicalPort11.setAttribute(IAttributeStore.RESOURCE_EXTERNAL_ID, PHYSICAL_PORT_11_EXTERNAL_ID);
+		physicalPort12.setAttribute(IAttributeStore.RESOURCE_EXTERNAL_ID, PHYSICAL_PORT_12_EXTERNAL_ID);
+		physicalPort21.setAttribute(IAttributeStore.RESOURCE_EXTERNAL_ID, PHYSICAL_PORT_21_EXTERNAL_ID);
+		physicalPort22.setAttribute(IAttributeStore.RESOURCE_EXTERNAL_ID, PHYSICAL_PORT_22_EXTERNAL_ID);
 
 		// create link between switches
 		Link link = new Link(physicalNetwork.createLink(), serviceProvider);
@@ -251,9 +250,9 @@ public class NetworkManagementTest {
 
 		// assert both ports contain the right external id
 		Assert.assertEquals("Virtual port of virtual switch 1 should be mapped to external port" + PHYSICAL_PORT_12_EXTERNAL_ID,
-				PHYSICAL_PORT_12_EXTERNAL_ID, createdOfSwitch1Port.getAttribute(NetworkManagement.PORT_INTERNAL_ID_ATTRIBUTE));
+				PHYSICAL_PORT_12_EXTERNAL_ID, createdOfSwitch1Port.getAttribute(IAttributeStore.RESOURCE_EXTERNAL_ID));
 		Assert.assertEquals("Virtual port of virtual switch 2 should be mapped to external port" + PHYSICAL_PORT_21_EXTERNAL_ID,
-				PHYSICAL_PORT_21_EXTERNAL_ID, createdOfSwitch2Port.getAttribute(NetworkManagement.PORT_INTERNAL_ID_ATTRIBUTE));
+				PHYSICAL_PORT_21_EXTERNAL_ID, createdOfSwitch2Port.getAttribute(IAttributeStore.RESOURCE_EXTERNAL_ID));
 
 		// assert network contains one link between the ports of the switches
 

--- a/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/NetworkManagement.java
+++ b/extensions/network/network.impl/src/main/java/org/mqnaas/network/impl/NetworkManagement.java
@@ -68,9 +68,7 @@ import org.slf4j.LoggerFactory;
  */
 public class NetworkManagement implements IRequestBasedNetworkManagement {
 
-	private static final Logger	log							= LoggerFactory.getLogger(NetworkManagement.class);
-
-	public static String		PORT_INTERNAL_ID_ATTRIBUTE	= "portInternalId";
+	private static final Logger	log	= LoggerFactory.getLogger(NetworkManagement.class);
 
 	public static boolean isSupporting(IRootResource rootResource) {
 		Type type = rootResource.getDescriptor().getSpecification().getType();
@@ -196,7 +194,7 @@ public class NetworkManagement implements IRequestBasedNetworkManagement {
 			resourceManagementListener.resourceAdded(newPort.getPortResource(),
 					serviceProvider.getCapability(resource, IPortManagement.class), IPortManagement.class);
 
-			newPort.setAttribute(PORT_INTERNAL_ID_ATTRIBUTE, physicalPort.getAttribute(PORT_INTERNAL_ID_ATTRIBUTE));
+			newPort.setAttribute(IAttributeStore.RESOURCE_EXTERNAL_ID, physicalPort.getAttribute(IAttributeStore.RESOURCE_EXTERNAL_ID));
 
 			virtualPortMapping.put(port, newPort.getPortResource());
 		}

--- a/extensions/network/network.impl/src/test/java/org/mqnaas/network/impl/NetworkManagementTest.java
+++ b/extensions/network/network.impl/src/test/java/org/mqnaas/network/impl/NetworkManagementTest.java
@@ -445,7 +445,7 @@ public class NetworkManagementTest {
 		phyPortAttributeStore.activate();
 		IAttributeStore slicedResourcePortAttributeStore = new AttributeStore();
 		ReflectionTestHelper.injectPrivateField(slicedResourcePortAttributeStore, new ConcurrentHashMap<String, String>(), "attributes");
-		phyPortAttributeStore.setAttribute(NetworkManagement.PORT_INTERNAL_ID_ATTRIBUTE, portExternalId);
+		phyPortAttributeStore.setAttribute(IAttributeStore.RESOURCE_EXTERNAL_ID, portExternalId);
 		PowerMockito.when(serviceProvider.getCapability(Mockito.eq(phyPort), Mockito.eq(IAttributeStore.class))).thenReturn(
 				phyPortAttributeStore);
 		PowerMockito.when(serviceProvider.getCapability(AdditionalMatchers.not(Mockito.eq(phyPort)), Mockito.eq(IAttributeStore.class))).thenReturn(
@@ -468,7 +468,7 @@ public class NetworkManagementTest {
 		// assert sliced resource has one port with mapped id
 		Assert.assertFalse("Slices resource should contain one port.", portManagement.getPorts().isEmpty());
 		Assert.assertEquals("Slices resource should contain one port.", 1, portManagement.getPorts().size());
-		Assert.assertEquals(portExternalId, slicedResourcePortAttributeStore.getAttribute(NetworkManagement.PORT_INTERNAL_ID_ATTRIBUTE));
+		Assert.assertEquals(portExternalId, slicedResourcePortAttributeStore.getAttribute(IAttributeStore.RESOURCE_EXTERNAL_ID));
 
 		Assert.assertEquals("Port map should have been fulfilled with one port.", 1, portsMap.size());
 		Assert.assertNotNull("Request port should have been mapped into a virtual one.", portsMap.get(virtPort));


### PR DESCRIPTION
NetworkManagement implementation was using its own (and wrong) key for searching external_ids in attribute store capabilities.
